### PR TITLE
Prevent GDI leak on save

### DIFF
--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -2500,9 +2500,11 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 			}
 			localCommandCacheSet.clear();
 
+			signTextEditor.setNotifyWords(false);
 			sentenceTranslate_Editor.save();
 			boolean success = textEditorController.save(this.text);
 			dirty.setDirty(!success);
+			signTextEditor.setNotifyWords(true);
 			return success;
 		}
 		return true;

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
@@ -157,6 +157,7 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 	private Map<String, IFigure> wordMap;
 	protected int selectedIndex;
 	private Adapter notifier;
+	private boolean notifyWords = true;
 	private LineFigure currentLineFigure;
 	private int lineIndex = 1;
 	private Map<Integer, LineFigure> lineMap = new HashMap<>();
@@ -191,6 +192,10 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 		createEditor();
 
 	}
+	
+	public void setNotifyWords(boolean value) {
+		notifyWords = value;
+	}
 
 	private void createEditor() {
 		this.setLayout(new FillLayout());
@@ -205,15 +210,18 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 
 			@Override
 			public void notifyChanged(final Notification notification) {
-				System.out.println(" notifyChanged " + notification);
-				
-				sync.asyncExec(new Runnable()
-				{
-					public void run()
+			
+				if (notifyWords) {
+					System.out.println(" notifyChanged " + notification);
+					
+					sync.asyncExec(new Runnable()
 					{
-						updateFigureFromWord(notification);
-					}
-				});
+						public void run()
+						{
+							updateFigureFromWord(notification);
+						}
+					});
+				}
 
 			}
 

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
@@ -950,9 +950,8 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 		
 		// dispose all images
 		for (Image im : imageList)
-		{
-			im.dispose();
-		}
+			if (!im.isDisposed())
+				im.dispose();
 		imageList.clear();
 		if (container != null) {
 			container.removeAll();
@@ -1729,6 +1728,9 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 					ImageFigure imf = (ImageFigure) fig;
 					String mdc = transformWordToMdCString(word);
 					try {
+						if (imf.getImage() != null)
+							if (!imf.getImage().isDisposed())
+								imf.getImage().dispose();
 						imf.setImage(transformToSWT(getImageData(mdc)));
 					} catch (MDCSyntaxError e) {
 						// TODO Auto-generated catch block


### PR DESCRIPTION
These changes prevent leaking of GDI objects and possible crashing when saving sign text editor contents.

