### PR TITLE
Prevent nullpointer in Lemmatizer lemma search preparation

### DIFF
--- a/org.bbaw.bts.core.services.corpus.impl/src/org/bbaw/bts/core/services/corpus/impl/services/BTSLemmaEntryServiceImpl.java
+++ b/org.bbaw.bts.core.services.corpus.impl/src/org/bbaw/bts/core/services/corpus/impl/services/BTSLemmaEntryServiceImpl.java
@@ -263,6 +263,9 @@ implements BTSLemmaEntryService, BTSObjectSearchService
 	public String processWordCharForLemmatizing(String chars) {
 		// TODO Auto-generated method stub
 		
+		if (chars == null)
+			return null;
+		
 		// cut left side
 		Matcher m = doublePointPattern.matcher(chars);
 		if (m.find())


### PR DESCRIPTION
Just one tiny thing:

  * Avoid frequent nullpointer in search string preparation for lemma proposal search with lemmatizer activated (*because it caused a lot of output in log file*).