### PR TITLE
Do not automatically change text editor visible range when selection is placed on object(s) in annotation model.

### DIFF
--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -1599,14 +1599,19 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 				Annotation anno = relatingObjectsAnnotations.get(0);
 				final Position pos = annotationModel.getPosition(anno);
 				if (pos != null)
-				{
 					sync.asyncExec(new Runnable() {
 						@SuppressWarnings("restriction")
 						public void run() {
-							embeddedEditor.getViewer().revealRange(pos.getOffset(), pos.length);
+							int topLeft = embeddedEditor.getViewer().getTopIndexStartOffset();
+							int botRight = embeddedEditor.getViewer().getBottomIndexEndOffset();
+							int caretPos = embeddedEditor.getViewer().getTextWidget().getCaretOffset();
+							// consider changing displayed range if annotation exceeds current range
+							// only jump if cursor would likely remain in visible range
+							if ((topLeft > pos.offset) || (botRight < pos.offset+pos.length))
+								if (botRight - caretPos > topLeft - pos.offset)
+									embeddedEditor.getViewer().revealRange(pos.getOffset(), pos.length);
 						}
 					});
-				}
 				
 			} catch (Exception e) {
 				e.printStackTrace();

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -1588,7 +1588,7 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 			if (btsEvent != null) {
 				btsEvent.setRelatingObjects(new ArrayList<BTSObject>(relSelObjects));
 			} else
-				revealAnnotation(relatingObjectsAnnotations);
+				revealAnnotation(relatingObjectsAnnotations, true);
 
 			// if (postSelection){
 			// eventBroker.post(
@@ -1606,7 +1606,7 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 		
 	}
 	
-	private void revealAnnotation(List<BTSModelAnnotation> relatingObjectsAnnotations) {
+	private void revealAnnotation(List<BTSModelAnnotation> relatingObjectsAnnotations, final boolean force) {
 		try {
 			// TODO annotations should be sorted based on startpos?
 			Annotation anno = relatingObjectsAnnotations.get(0);
@@ -1616,19 +1616,21 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 				sync.asyncExec(new Runnable() {
 					@SuppressWarnings("restriction")
 					public void run() {
-						int topLine = embeddedEditor.getViewer().getTopIndex();
-						int botLine = embeddedEditor.getViewer().getBottomIndex();
-						int caretPos = embeddedEditor.getViewer().getTextWidget().getCaretOffset();
-						int curLine = embeddedEditor.getViewer().getTextWidget().getLineAtOffset(caretPos);
-						int annoLineTop = embeddedEditor.getViewer().getTextWidget().getLineAtOffset(pos.offset);
-						int annoLineBot = embeddedEditor.getViewer().getTextWidget().getLineAtOffset(pos.offset+pos.length);
-						// consider changing displayed range if annotation exceeds current range
-						// only jump if cursor would likely remain in visible range
-						if ((topLine > annoLineTop) || (botLine < annoLineBot))
-							if (botLine - curLine >= topLine - annoLineTop) {
-								embeddedEditor.getViewer().revealRange(pos.getOffset(), pos.length);
-								System.out.println("jump "+pos.offset);
-							}
+						XtextSourceViewer viewer = embeddedEditor.getViewer();
+						if (!force) {
+							int topLine = viewer.getTopIndex();
+							int botLine = viewer.getBottomIndex();
+							int caretPos = viewer.getTextWidget().getCaretOffset();
+							int curLine = viewer.getTextWidget().getLineAtOffset(caretPos);
+							int annoLineTop = viewer.getTextWidget().getLineAtOffset(pos.offset);
+							int annoLineBot = viewer.getTextWidget().getLineAtOffset(pos.offset+pos.length);
+							// consider changing displayed range if annotation exceeds current range
+							// only jump if cursor would likely remain in visible range
+							if ((topLine > annoLineTop) || (botLine < annoLineBot))
+								if (botLine - curLine >= topLine - annoLineTop)
+									viewer.revealRange(pos.getOffset(), pos.length);
+						} else // jump regardless of cursor position
+							viewer.revealRange(pos.getOffset(), pos.length);
 					}
 				});	
 		} catch (Exception e) {

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -2830,25 +2830,22 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 							BTSModelAnnotation ma2 = modelAnnotationMap.get(ref
 									.getEndId());
 							Position pos = annotationModel.getPosition(ma1);
-							offset = pos.getOffset();
 							Position pos2 = annotationModel.getPosition(ma2);
-							if (pos != null && pos2 != null)
-							{
-								len = (pos2.getOffset() - pos.getOffset())
-									+ pos2.getLength();
-							}
-							else if (pos2 != null)
-							{
-								offset = pos2.getOffset();
-								len = pos2.getLength();
-							}
+							if (pos2 != null)
+								if (pos != null) {
+									offset = pos.getOffset();
+									len = (pos2.getOffset() - pos.getOffset())
+										+ pos2.getLength();
+								} else {
+									offset = pos2.getOffset();
+									len = pos2.getLength();
+								}
 						}
 						Issue issue;
 						issue = new Issue.IssueImpl();
 						Annotation annotation = makeAnnotation(object, issue, ref);
-						if (annotation != null) {
+						if (annotation != null)
 							annotationModel.addAnnotation(annotation, new Position(offset, len));
-						}
 					}
 				}
 			}

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -1586,21 +1586,16 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 				}
 			}
 			if (btsEvent != null) {
-				btsEvent.setRelatingObjects(relSelObjects);
-			}
+				btsEvent.setRelatingObjects(new ArrayList<BTSObject>(relSelObjects));
+			} else
+				revealAnnotation(relatingObjectsAnnotations);
+
 			// if (postSelection){
 			// eventBroker.post(
 			// BTSUIConstants.EVENT_TEXT_RELATING_OBJECTS_SELECTED,
 			// relSelObjects);
 			// }
 			
-			// XXX when text selection changes, both caret and selection events are triggered
-			// and their listener invoke this code.
-			// TODO decide whether automated revealing of annotation at cursor is desired
-			// (see https://telotadev.bbaw.de/redmine/issues/4854#change-14589)
-			// if so, don't do it in caret listener when in fact the text selection is being changed
-			/*if (!(btsEvent.getOriginalEvent() instanceof SelectionEvent))
-				revealAnnotation(relatingObjectsAnnotations);*/
 		}
 		// else if (postSelection)
 		// {

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -1602,13 +1602,16 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 					sync.asyncExec(new Runnable() {
 						@SuppressWarnings("restriction")
 						public void run() {
-							int topLeft = embeddedEditor.getViewer().getTopIndexStartOffset();
-							int botRight = embeddedEditor.getViewer().getBottomIndexEndOffset();
+							int topLine = embeddedEditor.getViewer().getTopIndex();
+							int botLine = embeddedEditor.getViewer().getBottomIndex();
 							int caretPos = embeddedEditor.getViewer().getTextWidget().getCaretOffset();
+							int curLine = embeddedEditor.getViewer().getTextWidget().getLineAtOffset(caretPos);
+							int annoLineTop = embeddedEditor.getViewer().getTextWidget().getLineAtOffset(pos.offset);
+							int annoLineBot = embeddedEditor.getViewer().getTextWidget().getLineAtOffset(pos.offset+pos.length);
 							// consider changing displayed range if annotation exceeds current range
 							// only jump if cursor would likely remain in visible range
-							if ((topLeft > pos.offset) || (botRight < pos.offset+pos.length))
-								if (botRight - caretPos > topLeft - pos.offset)
+							if ((topLine > annoLineTop) || (botLine < annoLineBot))
+								if (botLine - curLine >= topLine - annoLineTop)
 									embeddedEditor.getViewer().revealRange(pos.getOffset(), pos.length);
 						}
 					});


### PR DESCRIPTION

**1)** Do not display error message dialog when an annotation has been created without any text selected in transliteration editor. Just accept annotations without text item anchors.

**2)** Automatic alignment of transliteration text editor's visible range when the cursor is placed within an annotation was improved and then disabled. Reason:
  * Issue was filed pointing out that previous behaviour caused cursor to end up out of editor's visible range when placed within overly long annotations. This was fixed.
  * However, this feature also used to be invoked by selection listener, which results in unexpected behaviour when selecting text. Based on user feedback, implementation was deactivated (for now).