### PR TITLE
Fix application freeze on shutdown.

### DIFF
--- a/org.bbaw.bts.core.services.corpus.impl/src/org/bbaw/bts/core/services/corpus/impl/services/BTSLemmaEntryServiceImpl.java
+++ b/org.bbaw.bts.core.services.corpus.impl/src/org/bbaw/bts/core/services/corpus/impl/services/BTSLemmaEntryServiceImpl.java
@@ -263,6 +263,9 @@ implements BTSLemmaEntryService, BTSObjectSearchService
 	public String processWordCharForLemmatizing(String chars) {
 		// TODO Auto-generated method stub
 		
+		if (chars == null)
+			return null;
+		
 		// cut left side
 		Matcher m = doublePointPattern.matcher(chars);
 		if (m.find())

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -2500,10 +2500,12 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 			}
 			localCommandCacheSet.clear();
 
+			// turn word-wise graphical update on model change notifications off 
 			signTextEditor.setNotifyWords(false);
 			sentenceTranslate_Editor.save();
 			boolean success = textEditorController.save(this.text);
 			dirty.setDirty(!success);
+			// turn word-wise update back on
 			signTextEditor.setNotifyWords(true);
 			return success;
 		}

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -167,6 +167,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Shell;
@@ -605,6 +606,11 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 									BTSSentenceAnnotation.TYPE_HIGHLIGHTED)
 							.withParent(embeddedEditorComp);
 					
+					// remove disposelistener attached by embedded editor factory
+					// because it causes app to freeze on shutdown
+					for (Listener l : embeddedEditorComp.getListeners(SWT.Dispose))
+						embeddedEditorComp.removeListener(SWT.Dispose, l);
+
 					embeddedEditorModelAccess = embeddedEditor
 							.createPartialEditor("", "§§", "", false);
 					embeddedEditor.getViewer().getTextWidget()

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
@@ -193,6 +193,15 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 
 	}
 	
+	/**
+	 * (De)activates {@link BTSWord}-wise graphical update on model changes.
+	 * BTWord objects currently on display in sign text editor get
+	 * notified on changes in corresponding database objects. By default, such
+	 * notifications lead to updates of the word's graphical representation.
+	 * This can temporarily disabled when update is not desirable, e.g. before
+	 * save operations. 
+	 * @param value
+	 */
 	public void setNotifyWords(boolean value) {
 		notifyWords = value;
 	}

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/toolbar/StatusInformationToolControl.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/toolbar/StatusInformationToolControl.java
@@ -119,7 +119,7 @@ public class StatusInformationToolControl {
 				label.setText(message.getMessage() + message.getUserId());
 			}
 		}
-		else if (message != null)
+		else if (message != null && !label.isDisposed())
 		{
 			label.setText(message.getMessage());
 		}


### PR DESCRIPTION
Following behaviour has been reported to occur regularly:

> With a sufficiently large text (e.g. ~900 lines) in the transliteration editor, and its attached annotations / comments / rubra in reasonable number (~100) partially loaded into annotations part, any attempt to shutdown the application will fail and leave the application non-responsive for possibly several hours.
This problem can be avoided by relieving the editor such contents prior to shutdown (*e.g. by selecting a shorter text or any other object in the corpus navigator*).

This behaviour seems to be caused by a `DisposeListener`, which gets attached to the parent composite of an *xtext embedded edito*r when one is being built by the `EmbeddedEditorFactory`. On disposal of the parent composite, this listener tries to uninstall a *syntax highlighting helper* object, during which constantly dispatched text-change events caught (e.g.) by the transliteration editor's *line number ruler* lead to various layouting operations and allocation of display resources.

Although this process of shutting down the xtext embedded editor will eventually come to an end, it is incredibly time-consuming (*up to several hours easily, depending on current annotation model*), without serving any evident purpose.

**This can easily be fixed** by removing the silently attached dispose listener (as done with a41ea67ee0849deebecf774c9c262339a601afa1), without noticeable side-effects.

-----
The other changes are unrelated and include some documentation on previously merged fix (#1) and the nullpointer fix that has already been submitted in #5.


