### PR TITLE
Make processing of text selections more efficient.

### DIFF
--- a/org.bbaw.bts.ui.commons.corpus/src/org/bbaw/bts/ui/commons/corpus/events/BTSTextSelectionEvent.java
+++ b/org.bbaw.bts.ui.commons.corpus/src/org/bbaw/bts/ui/commons/corpus/events/BTSTextSelectionEvent.java
@@ -33,6 +33,7 @@ public class BTSTextSelectionEvent extends Event {
 		this.setOriginalEvent(event);
 		this.display = event.display;
 		this.widget = event.widget;
+		this.time = event.time;
 		if (event instanceof CaretEvent)
 		{
 			this.x = ((CaretEvent)event).caretOffset;

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -1488,6 +1488,7 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 				annotations.size());
 		if (!annotations.isEmpty())
 		{
+			BTSSenctence sentence = null;
 			for (BTSModelAnnotation ma : annotations) {
 				if (ma != null && ma instanceof BTSLemmaAnnotation
 						&& ma.getModel() != null
@@ -1496,7 +1497,7 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 					if (ma.getModel() instanceof BTSWord) {
 						setSentenceTranslation((BTSWord) ma.getModel());
 					} else if (ma.getModel() instanceof BTSSenctence) {
-						setSentenceTranslation((BTSSenctence) ma.getModel(), true);
+						sentence = (BTSSenctence) ma.getModel();
 					}
 					selectedTextItem = ma.getModel();
 
@@ -1521,13 +1522,15 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 				} else if (ma instanceof BTSModelAnnotation)
 				{
 					if (ma.getModel() instanceof BTSSenctence) {
-						setSentenceTranslation((BTSSenctence) ma.getModel(), true);
+						sentence = (BTSSenctence) ma.getModel();
 					} 
 					if (!ma.getModel().equals(selectedTextItem)) {
 						selectedTextItem = ma.getModel();
 					} 
 				}
 			}
+			if (sentence != null)
+				setSentenceTranslation(sentence, true);
 		}
 		else
 		{

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -2830,25 +2830,22 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 							BTSModelAnnotation ma2 = modelAnnotationMap.get(ref
 									.getEndId());
 							Position pos = annotationModel.getPosition(ma1);
-							offset = pos.getOffset();
 							Position pos2 = annotationModel.getPosition(ma2);
-							if (pos != null && pos2 != null)
-							{
-								len = (pos2.getOffset() - pos.getOffset())
-									+ pos2.getLength();
-							}
-							else if (pos2 != null)
-							{
-								offset = pos2.getOffset();
-								len = pos2.getLength();
-							}
+							if (pos2 != null)
+								if (pos != null) {
+									offset = pos.getOffset();
+									len = (pos2.getOffset() - pos.getOffset())
+										+ pos2.getLength();
+								} else {
+									offset = pos2.getOffset();
+									len = pos2.getLength();
+								}
 						}
 						Issue issue;
 						issue = new Issue.IssueImpl();
 						Annotation annotation = makeAnnotation(object, issue, ref);
-						if (annotation != null) {
+						if (annotation != null)
 							annotationModel.addAnnotation(annotation, new Position(offset, len));
-						}
 					}
 				}
 			}


### PR DESCRIPTION
(**Note:** *extra-detailed proposal to test/document own understanding! TL;DR below.*)

#### 0. Problem.
Currently, whenever some text in transliteration editor is selected, both caret and selection listener initiate the same computation/update processes necessary for correct presentation of objects related to the text range getting selected.

This works perfectly on relatively small texts, but with text objects and the number of objects related to them getting larger, it fails to run smoothly while multiline text selection takes place. 

The same goes for the translation part, as reported in [#5028](https://telotadev.bbaw.de/redmine/issues/5028).

In an attempt to reduce the amount of work being done to indicate relationships within a text selection, I propose two minor modifications:

#### 1. Delayed and selective invokation of text selection processing.
The responsible listener only schedule text selection processing (*including determination of related objects, consecutive sendings of  objects/events to multiple receivers via* Selection Service, *various editor/widget alignments, repaints, annotation model updates*), but this is not actually performed until it is somewhat save to assume that no further updates on the selected text range are to be expected. As soon as there have been no new selection/caret events for at least 350 milliseconds, it is considered save to begin processing. (*83d580c9d5993c93fc78d0b59c493a21d358b12d*)

To avoid double work, caret events are ignored whenever selection events are received simultaneously.

#### 2. Update sentence translation only once.
The transliteration editor part method `setSentenceTranslation` has to do a whole lot of stuff: put translations into the translation editor widget, update text editor models, repaint editors, send selections over to the translation part which itself needs to be updated accordingly.

Currently, when selecting a certain number of lines in transliteration editor, these tasks are run repeatedly (*and concurrently*) for every single line and sum up to such extent that the framework fails: the application quickly hits the *User Handle* limit of 10.000 that applies to system processes on windows, which raises errors and leaves the user with an incomplete operation.

Proposed solution (*2cc4518b59182694bf928e64c0f04070eb427c68*) avoids such overflows by reducing the number of `setSentenceTranslation` calls per selection processing. Only the selection's hindmost sentence object gets to propagate its translations. Effect on involved UI components are the same as before, but less events are sent, i.e. less resources allocated, and *`No more handles`* exception in main thread is far less likely.

----
**TL;DR:** Multiline text selection in transliteration editor/translation part is inefficient on large text objects with many related objects, resulting in decreasingly responsive user interface, failure in system resource allocation and potentially poor user experience. To improve this situation, naive elimination of redundancies is proposed in order to reduce work load.



