### PR TITLE
Fix determination of last sentence item in text selection. (Adding annotation)

### DIFF
--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -1719,26 +1719,27 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 						.getModel());
 				
 				// calculate start and end
-				if (((BTSModelAnnotation) a).getModel() instanceof BTSSentenceItem) {
-					Position pos = embeddedEditor.getViewer().getAnnotationModel()
-							.getPosition(a);
-					BTSSentenceItem item = (BTSSentenceItem) ((BTSModelAnnotation) a)
-							.getModel();
-					
-					if (startItem == null
-							// move selection offset to right if within an Ambivalence
-							|| (item.eContainer() instanceof BTSLemmaCase)) {
-						startItem = item;
-						pos.getOffset();
+				if (((BTSModelAnnotation) a).getModel() instanceof BTSSentenceItem) 
+					if  (!a.getClass().getSuperclass().equals(BTSModelAnnotation.class) 
+							|| a instanceof BTSLemmaAnnotation) {
+						Position pos = embeddedEditor.getViewer().getAnnotationModel()
+								.getPosition(a);
+						BTSSentenceItem item = (BTSSentenceItem) ((BTSModelAnnotation) a)
+								.getModel();
+
+						if (startItem == null
+								// move selection offset to right if within an Ambivalence
+								|| (item.eContainer() instanceof BTSLemmaCase)) {
+							startItem = item;
+						}
+						if (endItem == null
+								// move selection end to right if not within an Ambivalence
+								|| (!(item instanceof BTSAmbivalence) && pos.getOffset() + pos.getLength() > endItemOffeset)
+								|| (item.eContainer() instanceof BTSLemmaCase)) {
+							endItem = item;
+							endItemOffeset = pos.getOffset() + pos.getLength();
+						}
 					}
-					if (endItem == null
-							// move selection end to right if not within an Ambivalence
-							|| (!(item instanceof BTSAmbivalence) && pos.getOffset() + pos.getLength() > endItemOffeset)
-							|| (item.eContainer() instanceof BTSLemmaCase)) {
-						endItem = item;
-						endItemOffeset = pos.getOffset() + pos.getLength();
-					}
-				}
 			}
 		}
 


### PR DESCRIPTION
When choosing the hindmost sentence item being involved in a text selection event (`getModelAnnotationAtSelection`), model annotations at any position might mistakenly be chosen over successor candidates, as long as their model annotation range does not end within the text selection:

If the word sequence `jri np m r hw` has been selected, and there is an annotation that begins at `np`, but ends outside the selection, then in some cases the *`start`/`end`*-IDs assigned to the selection event will be those of `jri` and `np`. 
(*This only happens if said annotation at `np` has originally been retrieved during `loadInputTranscription`*)

This occasionaly causes newly created annotations with unexpected text ranges assigned, as described in issue [#5029](https://telotadev.bbaw.de/redmine/issues/5029), and most likely [#4806](https://telotadev.bbaw.de/redmine/issues/4806) and [#4798](https://telotadev.bbaw.de/redmine/issues/4798).

Problem could be fixed by ignoring any model annotations other than lemma annotations in the item selection process.

