### PR TITLE
Minor changes in text editor appearance.

### DIFF
--- a/org.bbaw.bts.ui.corpus.egy/fragment.e4xmi
+++ b/org.bbaw.bts.ui.corpus.egy/fragment.e4xmi
@@ -32,7 +32,7 @@
         <children xsi:type="menu:ToolBarSeparator" xmi:id="_y9kDIJ_tEeS8kttfrCiCZg" elementId="org.bbaw.bts.ui.corpus.egy.toolbarseparator.1"/>
         <children xsi:type="menu:HandledToolItem" xmi:id="_wCpCkJ_LEeS8kttfrCiCZg" elementId="org.bbaw.bts.ui.corpus.egy.handledtoolitem.9" iconURI="platform:/plugin/org.bbaw.bts.ui.resources.impl/icons/full/icon16/annotation-add.png" tooltip="Add Annotation" command="_ogEtgP0_EeOsAKche49RIg"/>
         <children xsi:type="menu:HandledToolItem" xmi:id="_2lIfMJ_LEeS8kttfrCiCZg" elementId="org.bbaw.bts.ui.corpus.egy.handledtoolitem." label="" iconURI="platform:/plugin/org.bbaw.bts.ui.resources.impl/icons/full/icon16/rubrum-add.png" tooltip="Add Rubrum" command="_vMxkwAawEeSOuJcvBP3MBw"/>
-        <children xsi:type="menu:HandledToolItem" xmi:id="_VNhk0J_MEeS8kttfrCiCZg" elementId="org.bbaw.bts.ui.corpus.egy.handledtoolitem.10" iconURI="platform:/plugin/org.bbaw.bts.ui.resources.impl/icons/full/icon16/subtext-add.png" tooltip="Add Subtext/Glosse" command="_1r5kUAawEeSOuJcvBP3MBw"/>
+        <children xsi:type="menu:HandledToolItem" xmi:id="_VNhk0J_MEeS8kttfrCiCZg" elementId="org.bbaw.bts.ui.corpus.egy.handledtoolitem.10" iconURI="platform:/plugin/org.bbaw.bts.ui.resources.impl/icons/full/icon16/subtext-add.png" tooltip="Add Glosse" command="_1r5kUAawEeSOuJcvBP3MBw"/>
         <children xsi:type="menu:HandledToolItem" xmi:id="_eGJLUJ_MEeS8kttfrCiCZg" elementId="org.bbaw.bts.ui.corpus.egy.handledtoolitem.11" iconURI="platform:/plugin/org.bbaw.bts.ui.resources.impl/icons/full/icon16/comment-add.png" tooltip="Add Comment" command="_GXtaUAaxEeSOuJcvBP3MBw"/>
       </toolbar>
     </elements>
@@ -277,7 +277,7 @@
         <children xsi:type="menu:ToolBarSeparator" xmi:id="_JBI1EPTSEeSQXI5ezOq8Qg" elementId="org.bbaw.bts.ui.corpus.egy.toolbarseparator.1"/>
         <children xsi:type="menu:HandledToolItem" xmi:id="_JBI1EfTSEeSQXI5ezOq8Qg" elementId="org.bbaw.bts.ui.corpus.egy.handledtoolitem.9" iconURI="platform:/plugin/org.bbaw.bts.ui.resources.impl/icons/full/icon16/annotation-add.png" tooltip="Add Annotation" command="_ogEtgP0_EeOsAKche49RIg"/>
         <children xsi:type="menu:HandledToolItem" xmi:id="_JBI1EvTSEeSQXI5ezOq8Qg" elementId="org.bbaw.bts.ui.corpus.egy.handledtoolitem." label="" iconURI="platform:/plugin/org.bbaw.bts.ui.resources.impl/icons/full/icon16/rubrum-add.png" tooltip="Add Rubrum" command="_vMxkwAawEeSOuJcvBP3MBw"/>
-        <children xsi:type="menu:HandledToolItem" xmi:id="_JBI1E_TSEeSQXI5ezOq8Qg" elementId="org.bbaw.bts.ui.corpus.egy.handledtoolitem.10" iconURI="platform:/plugin/org.bbaw.bts.ui.resources.impl/icons/full/icon16/subtext-add.png" tooltip="Add Subtext/Glosse" command="_1r5kUAawEeSOuJcvBP3MBw"/>
+        <children xsi:type="menu:HandledToolItem" xmi:id="_JBI1E_TSEeSQXI5ezOq8Qg" elementId="org.bbaw.bts.ui.corpus.egy.handledtoolitem.10" iconURI="platform:/plugin/org.bbaw.bts.ui.resources.impl/icons/full/icon16/subtext-add.png" tooltip="Add Glosse" command="_1r5kUAawEeSOuJcvBP3MBw"/>
         <children xsi:type="menu:HandledToolItem" xmi:id="_JBI1FPTSEeSQXI5ezOq8Qg" elementId="org.bbaw.bts.ui.corpus.egy.handledtoolitem.11" iconURI="platform:/plugin/org.bbaw.bts.ui.resources.impl/icons/full/icon16/comment-add.png" tooltip="Add Comment" command="_GXtaUAaxEeSOuJcvBP3MBw"/>
       </toolbar>
     </elements>

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -2711,6 +2711,7 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 													.getTextWidget()
 													.setCaretOffset(
 															cachedCursor);
+											embeddedEditor.getViewer().revealRange(cachedCursor, 0);
 										} catch (Exception e) {
 										}
 									}


### PR DESCRIPTION
Two changes as requested in issue tracker.

  * After *Load Lemmata* action, not only restore cursor position, but also reveal it in editor.
  * Change tooltip text of button for new range-specific Glosse.