### PR TITLE
[WIP] Edit-robust annotations - Do not merge!

### DIFF
--- a/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/BTSTextEditorControllerImpl.java
+++ b/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/BTSTextEditorControllerImpl.java
@@ -183,9 +183,10 @@ public class BTSTextEditorControllerImpl implements BTSTextEditorController
 			lineLength = DEFAULT_LINE_LENGTH;
 		}
 		annotationRangeMap = new HashMap<BTSInterTextReference, AnnotationCache>();
-		if (relatingObjects != null && ! relatingObjects.isEmpty())// && (relatingObjectsMap == null || relatingObjectsMap.isEmpty()))
+		if (relatingObjects != null && !relatingObjects.isEmpty())// && (relatingObjectsMap == null || relatingObjectsMap.isEmpty()))
 		{
-			relatingObjectsMap = fillRelatingObjectsMap(relatingObjects);
+			relatingObjectsMap.clear();
+			relatingObjectsMap.putAll(fillRelatingObjectsMap(relatingObjects));
 		}
 		
 			

--- a/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/support/TextModelHelper.java
+++ b/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/support/TextModelHelper.java
@@ -184,6 +184,7 @@ public class TextModelHelper {
 		{
 			if (an instanceof BTSModelAnnotation && clazz.isInstance(((BTSModelAnnotation)an).getModel()))
 			{
+				// XXX erstbeste?
 				return (BTSModelAnnotation) an;
 			}
 		}

--- a/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/utils/BTSUIConstants.java
+++ b/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/utils/BTSUIConstants.java
@@ -135,6 +135,9 @@ public class BTSUIConstants {
 	public static final Color COLOR_RUBRUM= _resources
 			.createColor(new RGB(255, 106, 106));
 	
+	/** Background color for recognized word objects. **/
+	public static final Color COLOR_WORD = _resources.createColor(new RGB(248, 255, 255));
+	
 	
 	/** The Constant PASSPORT_COLUMN_NUMBER. */
 	public static final int PASSPORT_COLUMN_NUMBER = 6;

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -726,21 +726,9 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 
 								}
 							});
+
 					// add an inclusive position updater, because default updater won't update positions
 					// at the end of which text gets inserted
-					/*Map<Integer, DefaultPositionUpdater> defaultUpdaters = new HashMap<Integer, DefaultPositionUpdater>();
-					int counter = 0;
-					for (IPositionUpdater updater : embeddedEditor.getDocument().getPositionUpdaters()) {
-						counter += 1;
-						if (updater instanceof DefaultPositionUpdater && !updater.getClass().getSuperclass().equals(DefaultPositionUpdater.class))
-							defaultUpdaters.put(counter, (DefaultPositionUpdater)updater);
-					}
-					for (Entry<Integer, DefaultPositionUpdater> e : defaultUpdaters.entrySet()) {
-						DefaultPositionUpdater updater = e.getValue();
-						embeddedEditor.getDocument().removePositionUpdater(updater);
-						embeddedEditor.getDocument().insertPositionUpdater(new InclusivePositionUpdater(updater.get), e.getKey());
-					}*/
-							
 					embeddedEditor.getDocument().addPositionUpdater(new DefaultInclusivePositionUpdater(IDocument.DEFAULT_CATEGORY));
 					
 					
@@ -1469,10 +1457,8 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 	 */
 	protected void processTextModification(DocumentEvent event) {
 		IDocument doc = event.getDocument();
-		for (IPositionUpdater pu : doc.getPositionUpdaters())
-			System.out.println(pu+"; ");
-		System.out.println();
-		String cat = IDocument.DEFAULT_CATEGORY;
+		System.out.println("relating objects: "+((relatingObjects != null)?relatingObjects.size():0));
+		System.out.println("relating objects map: "+((relatingObjectsMap != null)?relatingObjectsMap.size():0));
 		try {
 			for (String c : doc.getPositionCategories()) {
 				System.out.print(c+": ");
@@ -1486,22 +1472,134 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 		System.out.println("document changed: "+event+"; "+event.fModificationStamp);
 		System.out.println(": "+event.getOffset()+", "+event.fOffset+", "+event.getText());
 		BTSTextSelectionEvent textEvent = new BTSTextSelectionEvent(new TypedEvent(event), text);
-		for (BTSModelAnnotation a : getModelAnnotationAtSelection(event.fOffset-event.getText().length(), event.getText().length(), textEvent)) {
-			System.out.println(a+" - "+a.getModel());
-			if (!a.getClass().getSuperclass().equals(BTSModelAnnotation.class))
-					if (a instanceof BTSModelAnnotation){
-						System.out.println((BTSSentenceItem)a.getModel());
-						Position p = annotationModel.getPosition(a);
-						/*if (p.offset+p.length == event.fOffset+EgyTextEditorPart.EDITOR_PREFIX_LENGTH-event.fText.length()
-							|| p.offset == event.fOffset+EgyTextEditorPart.EDITOR_PREFIX_LENGTH-event.fText.length()) {
-							p.length += event.fText.length();
-							System.out.println("update length: "+p.length);
-						}*/
-					}
+		List<BTSModelAnnotation> erased = new Vector<BTSModelAnnotation>();
+		Map<String, Set<BTSModelAnnotation>> annosAtAnchor = new HashMap<String, Set<BTSModelAnnotation>>();
+		for (BTSModelAnnotation a : getModelAnnotationAtSelection(event.fOffset-event.getText().length()-1, event.fOffset+event.getText().length()+1, textEvent)) {
+			Position p = annotationModel.getPosition(a);
+			System.out.println(annoPos(a)+" "+a+" - "+a.getModel());
+			BTSInterTextReference ref = a.getInterTextReference();
+			if (ref != null) {
+				System.out.println(" "+ref.getBeginId() + " -- " + ref.getEndId());
+				Set<BTSModelAnnotation> annotations = annosAtAnchor.get(ref.getBeginId());
+				annotations = (annotations != null) ? annotations : new HashSet<BTSModelAnnotation>();
+				annotations.add(a);
+				annosAtAnchor.put(ref.getBeginId(), annotations);
+				annotations = annosAtAnchor.get(ref.getEndId());
+				annotations = (annotations != null) ? annotations : new HashSet<BTSModelAnnotation>();
+				annotations.add(a);
+				annosAtAnchor.put(ref.getEndId(), annotations);
+			}
+			
+			//if (!a.getClass().getSuperclass().equals(BTSModelAnnotation.class)) {
+			{
+				if (p.getLength() < 1)
+					erased.add(a);
+					/*if (p.offset+p.length == event.fOffset+EgyTextEditorPart.EDITOR_PREFIX_LENGTH-event.fText.length()
+						|| p.offset == event.fOffset+EgyTextEditorPart.EDITOR_PREFIX_LENGTH-event.fText.length()) {
+						p.length += event.fText.length();
+						System.out.println("update length: "+p.length);
+					}*/
+			}
 		}
-		System.out.println(textEvent.getStartId()+" -- "+textEvent.getEndId());	
+		System.out.println(textEvent.getStartId()+" -- "+textEvent.getEndId());
+		
+		// iterate through 0-length annotations
+		for (BTSModelAnnotation a : erased) {
+			Position p = annotationModel.getPosition(a);
+			System.out.println(annoPos(a)+": "+(BTSSentenceItem)a.getModel());
+			BTSIdentifiableItem modelItem = (BTSIdentifiableItem)a.getModel();
+			String modelItemId = modelItem.get_id();
+			System.out.println(" model annotation of length 0! "+modelItemId);
+			System.out.println(" entries in relatingObjectMap: ");
+			if (relatingObjectsMap.get(modelItemId) != null)
+				for (BTSInterTextReference refs : relatingObjectsMap.get(modelItemId))
+					System.out.println("  "+refs.eContainer()+" "+refs.eContainer().eContainer());
+			//System.out.println("entries in modelAnnotationMap: ");
+			//System.out.println(" "+modelAnnotationMap.get(modelItemId));
+			boolean replaced = true;
+			System.out.println(" hooked to annotations: ");
+			if (annosAtAnchor.get(modelItemId) != null)
+				for (BTSModelAnnotation ma : annosAtAnchor.get(modelItemId)) {
+					System.out.println("  "+annoPos(ma)+": "+ma);
+					if (ma.getClass().getSuperclass().equals(BTSModelAnnotation.class)) {
+						System.out.println("   model: "+ma.getModel());
+						Position map = annotationModel.getPosition(ma);
+						if (map.length > 0) {
+							System.out.println("    remove hook");
+							replaced &= removeAnnotationHook(ma, modelItem);
+						} else {
+							System.out.println("    annotation itself needs to be removed.");
+							annotationModel.removeAnnotation(ma);
+							doc.removePosition(map);
+						}
+					}
+				}
+			if (replaced) {
+				System.out.println("    remove annotation at "+annoPos(a));
+				annotationModel.removeAnnotation(a);
+				doc.removePosition(p);
+			} else
+				System.out.println("    replacing hook failed: "+a);
+				
+				
+		}
+
 	}
 	
+
+	private String annoPos(BTSModelAnnotation a) {
+		Position p = annotationModel.getPosition(a);
+		return "["+p.offset+"-"+(p.offset+p.length)+"]";
+	}
+	
+	private boolean removeAnnotationHook(BTSModelAnnotation annotation, BTSIdentifiableItem hook) {
+		BTSInterTextReference ref = annotation.getInterTextReference();
+		boolean startHook = hook.get_id().equals(ref.getBeginId());
+		System.out.println("    annotation from "+ref.getBeginId()+"--"+ref.getEndId());
+		System.out.println("    Try to replace "+(startHook?"start":"end")+" hook "+hook);
+		Position pos = annotationModel.getPosition(annotation);
+		List<BTSModelAnnotation> includes = getModelAnnotationAtSelection(pos.offset, pos.offset+pos.length, null);
+		System.out.println("    Annotations within "+annoPos(annotation)+":");
+		
+		BTSModelAnnotation newHook = null;
+		
+		for (BTSModelAnnotation a : includes) {
+			System.out.println("     "+annoPos(a)+": "+a);
+			
+			if (!a.getClass().getSuperclass().equals(BTSModelAnnotation.class)
+					|| a instanceof BTSLemmaAnnotation) {
+				System.out.println("     "+annoPos(a)+"hook candidate "+": "+a.getModel().get_id()+" "+a.getModel());
+				Position p = annotationModel.getPosition(a);
+				if (p.length > 0)
+					if (startHook) {
+						if (newHook == null)
+							newHook = a;
+					} else
+						newHook = a;
+			}
+			
+		}
+		
+		if (newHook != null) {
+			System.out.println("     proposed new hook "+annoPos(newHook)+": "+newHook.getModel().get_id()+" "+newHook.getModel());
+			Position p = annotationModel.getPosition(newHook);
+			if (startHook) {
+				ref.setBeginId(newHook.getModel().get_id());
+				pos.setOffset(p.offset);
+			} else {
+				ref.setEndId(newHook.getModel().get_id());
+				pos.setLength(p.offset+p.length-pos.offset);
+			}
+			System.out.println("     "+annotation.getModel());
+			System.out.println("     "+annotation.getRelatingObject());
+			// TODO save annotation via controller
+			/*if (annotation.getRelatingObject() instanceof BTSAnnotation)
+				((BTSAnnotation)annotation.getRelatingObject()).*/
+			return true;
+		}
+		
+		return false;
+	}
 	
 	/**
 	 * Process text selection.
@@ -1510,6 +1608,8 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 	 */
 	protected void processTextSelection(TypedEvent event) {
 		BTSTextSelectionEvent btsEvent = new BTSTextSelectionEvent(event, text);
+		System.out.println("Textselection x y : " + btsEvent.x + " " +
+		 btsEvent.y);
 		btsEvent.data = text;
 		
 		if (this.btsTextEvent == null) {
@@ -1697,6 +1797,8 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 		// BTSUIConstants.EVENT_TEXT_RELATING_OBJECTS_SELECTED,
 		// null);
 		// }
+		if (btsEvent != null)
+			System.out.println("text selection event spans "+btsEvent.getStartId()+" -- "+btsEvent.getEndId());
 		
 	}
 	
@@ -1769,6 +1871,7 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 	@SuppressWarnings("restriction")
 	private List<BTSModelAnnotation> getModelAnnotationAtSelection(int start,
 			int end, BTSTextSelectionEvent btsEvent) {
+		System.out.println("getting annotations between "+start+"--"+end);
 		Iterator it = embeddedEditor.getViewer().getAnnotationModel()
 				.getAnnotationIterator();
 		List<BTSModelAnnotation> annotations = new Vector<BTSModelAnnotation>(4);
@@ -1784,7 +1887,7 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 						.getPosition(a);
 				// System.out.println("pos " + pos.getOffset() + " " +
 				// pos.getOffset() + pos.getLength());
-				if ((start + 1 >= pos.getOffset() && start < pos.getOffset()
+				if ((start >= pos.getOffset() && start < pos.getOffset()
 						+ pos.getLength())
 						|| (start <= pos.getOffset() && end >= pos.getOffset())) {
 					List<BTSModelAnnotation> list = annotationOffsetMap.get(pos.getOffset());

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -134,8 +134,10 @@ import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.dialogs.ProgressMonitorDialog;
 import org.eclipse.jface.operation.IRunnableWithProgress;
+import org.eclipse.jface.text.BadPositionCategoryException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.DocumentEvent;
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IDocumentListener;
 import org.eclipse.jface.text.IPainter;
 import org.eclipse.jface.text.Position;
@@ -173,6 +175,8 @@ import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Menu;
 import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.Shell;
+import org.eclipse.xtext.nodemodel.INode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.ui.editor.XtextSourceViewer;
 import org.eclipse.xtext.ui.editor.embedded.EmbeddedEditor;
@@ -616,16 +620,19 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 							.newEditor(xtextResourceProvider)
 							.showAnnotations(BTSAnnotationAnnotation.TYPE,
 									BTSCommentAnnotation.TYPE,
+									BTSModelAnnotation.TYPE,
 									"org.eclipse.xtext.ui.editor.error",
 									"org.eclipse.xtext.ui.editor.warning",
 									BTSSentenceAnnotation.TYPE_HIGHLIGHTED)
 							.withParent(embeddedEditorComp);
 					
+					
+					
 					embeddedEditorModelAccess = embeddedEditor
 							.createPartialEditor("", "§§", "", false);
 					embeddedEditor.getViewer().getTextWidget()
 							.setLineSpacing(LINE_SPACE);
-
+					
 
 					// embeddedEditor.getViewer().getTextWidget().setFont(font);
 					// keep the partialEditor as instance var to read / write

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/support/AbstractTextEditorLogic.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/support/AbstractTextEditorLogic.java
@@ -1,9 +1,5 @@
 package org.bbaw.bts.ui.egy.parts.support;
 
-import java.util.Map;
-
-import org.bbaw.bts.btsmodel.BTSIdentifiableItem;
-import org.bbaw.bts.corpus.btsCorpusModel.BTSWord;
 import org.bbaw.bts.ui.commons.corpus.text.BTSAnnotationAnnotation;
 import org.bbaw.bts.ui.commons.corpus.text.BTSCommentAnnotation;
 import org.bbaw.bts.ui.commons.corpus.text.BTSLemmaAnnotation;
@@ -13,22 +9,15 @@ import org.bbaw.bts.ui.commons.corpus.text.BTSSubtextAnnotation;
 import org.bbaw.bts.ui.commons.utils.BTSUIConstants;
 import org.bbaw.bts.ui.egy.parts.egyTextEditor.AnnotationDrawingStrategy;
 import org.bbaw.bts.ui.egy.parts.egyTextEditor.AnnotationHighlightedDrawingStrategy;
-import org.bbaw.bts.ui.egy.parts.egyTextEditor.BTSTextXtextEditedResourceProvider;
 import org.bbaw.bts.ui.egy.parts.egyTextEditor.CommentDrawingStrategy;
 import org.bbaw.bts.ui.egy.parts.egyTextEditor.CommentHighlightedDrawingStrategy;
 import org.bbaw.bts.ui.egy.parts.egyTextEditor.RubrumDrawingStrategy;
 import org.bbaw.bts.ui.egy.parts.egyTextEditor.SubtextHighlightedDrawingStrategy;
 import org.bbaw.bts.ui.egy.parts.egyTextEditor.SubtextdrawingStrategy;
-import org.eclipse.emf.ecore.EObject;
-import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.AnnotationPainter;
-import org.eclipse.jface.text.source.AnnotationPainter.SquigglesStrategy;
-import org.eclipse.jface.text.source.IAnnotationAccess;
-import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.jface.text.source.AnnotationPainter.ITextStyleStrategy;
-import org.eclipse.xtext.ui.editor.embedded.EmbeddedEditor;
-import org.eclipse.xtext.validation.Issue;
+import org.eclipse.jface.text.source.IAnnotationAccess;
 
 public abstract class AbstractTextEditorLogic {
 	

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/support/AbstractTextEditorLogic.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/support/AbstractTextEditorLogic.java
@@ -40,12 +40,19 @@ public abstract class AbstractTextEditorLogic {
 			}
 		};
 		
+		// Sentence
 		AnnotationDrawingStrategy sentenceStrategy2 = new AnnotationDrawingStrategy();
 		painter.addDrawingStrategy(BTSSentenceAnnotation.TYPE_HIGHLIGHTED, sentenceStrategy2);
 		painter.setAnnotationTypeColor(BTSSentenceAnnotation.TYPE_HIGHLIGHTED,
 				BTSUIConstants.COLOR_SENTENCE);
 		painter.addAnnotationType(BTSSentenceAnnotation.TYPE_HIGHLIGHTED, BTSSentenceAnnotation.TYPE_HIGHLIGHTED);
 
+		// Word
+		ITextStyleStrategy ws = new org.eclipse.jface.text.source.AnnotationPainter.HighlightingStrategy();
+		painter.addTextStyleStrategy(BTSModelAnnotation.TYPE, ws);
+		painter.setAnnotationTypeColor(BTSModelAnnotation.TYPE, BTSUIConstants.COLOR_WORD);
+		painter.addAnnotationType(BTSModelAnnotation.TYPE, BTSModelAnnotation.TYPE);
+		
 		// Lemma
 		ITextStyleStrategy strategy = new org.eclipse.jface.text.source.AnnotationPainter.HighlightingStrategy();
 		painter.addTextStyleStrategy(BTSLemmaAnnotation.TYPE, strategy);

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/support/DefaultInclusivePositionUpdater.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/support/DefaultInclusivePositionUpdater.java
@@ -1,0 +1,109 @@
+/**
+ * This file is part of Berlin Text System.
+ * 
+ * The software Berlin Text System serves as a client user interface for working with
+ * text corpus data. See: aaew.bbaw.de
+ * 
+ * The software Berlin Text System was developed at the Berlin-Brandenburg Academy
+ * of Sciences and Humanities, Jägerstr. 22/23, D-10117 Berlin.
+ * www.bbaw.de
+ * 
+ * Copyright (C) 2013-2014  Berlin-Brandenburg Academy
+ * of Sciences and Humanities
+ * 
+ * The software Berlin Text System was developed by @author: Christoph Plutte.
+ * 
+ * Berlin Text System is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Berlin Text System is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Berlin Text System.  
+ * If not, see <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ */
+package org.bbaw.bts.ui.egy.parts.support;
+
+import org.bbaw.bts.ui.egy.parts.EgyTextEditorPart;
+import org.eclipse.jface.text.BadPositionCategoryException;
+import org.eclipse.jface.text.DefaultPositionUpdater;
+import org.eclipse.jface.text.DocumentEvent;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.link.InclusivePositionUpdater;
+
+/**
+ * Updates only {@link Position}s of the specified category that
+ * {@link DefaultPositionUpdater} fails to give an accurate length,
+ * i.e. those at the end of which a {@link DocumentEvent} appended
+ * new trailing characters.
+ * 
+ * @author hoeper
+ *
+ */
+public class DefaultInclusivePositionUpdater extends InclusivePositionUpdater {
+
+	public DefaultInclusivePositionUpdater(String category) {
+		super(category);
+	}
+	
+	@Override
+	public void update(DocumentEvent event) {
+
+		int eventOffset= event.getOffset();
+		int eventOldLength= event.getLength();
+		int eventNewLength= event.getText() == null ? 0 : event.getText().length();
+		int deltaLength= eventNewLength - eventOldLength;
+
+		if (eventNewLength > 0)
+			try {
+				Position[] positions= event.getDocument().getPositions(getCategory());
+	
+				for (int i= 0; i != positions.length; i++) {
+	
+					Position position= positions[i];
+	
+					if (position.isDeleted()) {
+						System.out.println("position has been deleted: "+position);
+						continue;
+					}
+	
+					int offset= position.getOffset();
+					int length= position.getLength();
+					int end= offset + length;
+	
+					if (offset == eventOffset + eventNewLength) { // + eventOldLength
+						// position begins immediately after textchange - adjust length, shift offset
+						int newOffset = eventOffset;
+						position.setOffset(newOffset);
+						position.setLength(end-newOffset);
+						System.out.println("update position ["+offset+"-"+(end)+"] -> ["+newOffset+"-"+end+"]");
+					} else if (offset > eventOffset + eventOldLength) {
+						// position comes way
+						// after change - leave alone
+					} else if (end < eventOffset) {
+						// position comes way before change -
+						// leave alone
+					} else if (offset <= eventOffset && end > eventOffset + eventOldLength) {
+						// event completely internal to the position - leave alone
+					} else if (offset < eventOffset) {
+						// event extends over end of position - adjust length
+						int newEnd= eventOffset + eventNewLength;
+						System.out.println("update position ["+offset+"-"+(offset+length)+"] -> ["+offset+"-"+newEnd+"]");
+						position.setLength(newEnd - offset);
+					} else if (end > eventOffset + eventOldLength) {
+						// event extends from before position into it - leave alone
+					} else {
+						// event consumes the position - leave alone
+					}
+				}
+			} catch (BadPositionCategoryException e) {
+				// ignore and return
+			}
+	}
+	
+}


### PR DESCRIPTION
There is probably no point in reviewing these changes yet.

Certain text changes in transliteration editor can cause annotations to lose the word objects they refer to. Especially deletion of words that mark a starting/ending point of annotations are not consistenly reflected in the data model. So there is an risk of annotations losing most or all of their assigned text range.

A very simple and messily hacked approach of handling the risky text changes suggests that this can be fixed. Two additional measures are being taken whenever a `DocumentEvent` indicates text change:

  * Apply an additional `IPositionUpdater` to the entire document to make sure that positions being extended by text insertion at their very beginning or end get updated accordingly.
  * Test positions affected by a text event against their length being reduced to zero, i.e. if they are being deleted by the change. If so, and their disappearance affects annotation ranges, search among all of the remaining words within the affected `BTSInterTextReference` for a replacement for the deleted word.

Though not extensively tested so far, this seems to help a lot. Only thing is, `EgyTextEditorPart` can't save annotation objects, so the repaired annotation ranges are not persistent yet. How could they be persisted?

Do you see any problems with this approach or should I keep going until this branch contains something presentable?

