### PR TITLE
Fix 'copy with lemmata' editor command.

### DIFF
--- a/org.bbaw.bts.ui.corpus.egy/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.ui.corpus.egy/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CorpusUIEgyptian
 Bundle-SymbolicName: org.bbaw.bts.ui.corpus.egy;singleton:=true
-Bundle-Version: 1.0.13.qualifier
+Bundle-Version: 1.0.14.qualifier
 Bundle-ClassPath: .,
  swing2swt.jar
 Bundle-Activator: org.bbaw.bts.ui.egy.internal.Activator

--- a/org.bbaw.bts.ui.corpus.egy/pom.xml
+++ b/org.bbaw.bts.ui.corpus.egy/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.corpus.egy</artifactId>
-  <version>1.0.13-SNAPSHOT</version>
+  <version>1.0.14-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -1510,8 +1510,8 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 				}
 			};
 			this.delaySelectionJob.schedule(400);
-		} else if (!(event instanceof CaretEvent) || (this.btsTextEvent != null) 
-				|| (btsTextEvent.getOriginalEvent() instanceof CaretEvent))
+		} else if (!(event instanceof CaretEvent) || (this.btsTextEvent == null)
+			|| (this.btsTextEvent.getOriginalEvent() instanceof CaretEvent))
 			this.btsTextEvent = btsEvent;
 		this.lastSelectionTimeStamp = System.nanoTime();
 	}

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -735,17 +735,18 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 						public void menuShown(MenuEvent e) {
 							
 							
-							if (checkTransliterationHasNoErrors(text))
-							{
-								 MenuItem itemCopy = new MenuItem((Menu) menu, SWT.NONE);
-					             itemCopy.setText("Copy with Lemmata" );
-					             itemCopy.addSelectionListener(new SelectionAdapter() {
+							if (checkTransliterationHasNoErrors(text)) {
+								if (!btsTextEvent.getSelectedItems().isEmpty()) {
+									MenuItem itemCopy = new MenuItem((Menu) menu, SWT.NONE);
+						            itemCopy.setText("Copy with Lemmata" );
+						            itemCopy.addSelectionListener(new SelectionAdapter() {
 									
-									@Override
-									public void widgetSelected(SelectionEvent e) {
-										copyTextWithLemmata();
-									}
-								});
+										@Override
+										public void widgetSelected(SelectionEvent e) {
+											copyTextWithLemmata();
+										}
+						            });
+								}
 								if (deepCopyCache != null)
 								{
 									MenuItem itemPaste = new MenuItem((Menu) menu, SWT.NONE);
@@ -1165,6 +1166,8 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 	}
 
 	private boolean checkTransliterationHasNoErrors(BTSText text2) {
+		// XXX irgendwo fehler: wenn vorher irgendwann man errors drin waren,
+		// bleibt das auch wenn man den text wechselt...
 		IXtextDocument document = embeddedEditor.getDocument();
 
 		EList<EObject> objects = document

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -1253,6 +1253,22 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 	@SuppressWarnings({ "rawtypes", "restriction" })
 	protected void loadInputTranscription(BTSText localtext,
 			List<BTSObject> localRelatingObjects, IProgressMonitor monitor) {
+
+		if (delaySelectionJob != null)
+			delaySelectionJob.cancel();
+		delaySelectionJob = new Job("text_selection_processing_sleeping"){
+			@Override
+			protected IStatus run(IProgressMonitor monitor) {
+				long t = System.currentTimeMillis();
+				while (System.currentTimeMillis() < t+3000)
+					try {
+						Thread.sleep(500);
+					} catch (Exception e) {}
+				delaySelectionJob = null;
+				return Status.OK_STATUS;
+			}
+		};
+
 		text = localtext;
 		loading = true;
 		lemmaAnnotationMap = new HashMap<String, List<Object>>();
@@ -1334,6 +1350,7 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 		oruler.update();
 
 		loading = false;
+		delaySelectionJob.schedule();
 	}
 	
 	/**

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -898,6 +898,7 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 			
 			cachedCursor = embeddedEditor.getViewer().getTextWidget()
 					.getCaretOffset();
+			final int len = ev.y - ev.x;
 			updateModelFromTranscription();
 			
 			//selectedTextItem
@@ -1019,6 +1020,7 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 												.getTextWidget()
 												.setCaretOffset(
 														cachedCursor);
+										embeddedEditor.getViewer().revealRange(cachedCursor, len);
 									} catch (Exception e) {
 									}
 								}


### PR DESCRIPTION
Previous changes in transliteration editor text selection processing broke functions 'copy with lemmata' and 'paste with lemmata'. These functions make use of the `btsTextEvent` field, but in order to optimize text event processing, that variable became a state indicator and was frequently reset (83d580c).

This piggy-back stunt is hereby replaced. An additional field of type `Job` now serves as a processing state indicator and has the advantage that selection processing can be cancelled at any time. It can also be used to block processing of irrelevant text events, e.g. those that fire when the editor loads new contents, as done in 69703e0.

Additional improvements:
  * 'Copy with lemmata' entry in context menu is only shown if text selection actually contains something to copy (fbadd1a).
  * Editor makes sure to show text inserted by 'Paste with lemmata' command (86f6615).
  * Avoid nullpointer error when deciding whether to update scheduled text event (28cac61).

Because copy and paste of lemmatized text selection was broken in version 2.3.14, a patched plugin has been supplied, containing these changes. Hence the updated version numbers.


