### PR TITLE
Improve item order and object loading in User Manager dialog.

### DIFF
--- a/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/viewerSorter/BTSUserByNameViewerComparator.java
+++ b/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/viewerSorter/BTSUserByNameViewerComparator.java
@@ -1,0 +1,43 @@
+package org.bbaw.bts.ui.commons.viewerSorter;
+
+import org.bbaw.bts.btsmodel.BTSDBCollectionRoleDesc;
+import org.bbaw.bts.btsmodel.BTSProject;
+import org.bbaw.bts.btsmodel.BTSProjectDBCollection;
+import org.bbaw.bts.btsmodel.BTSUser;
+import org.bbaw.bts.btsmodel.BTSUserGroup;
+import org.bbaw.bts.btsviewmodel.TreeNodeWrapper;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.jface.viewers.ViewerComparator;
+import org.eclipse.jface.viewers.ViewerSorter;
+
+public class BTSUserByNameViewerComparator extends ViewerComparator {
+
+	@Override
+	public int compare(Viewer viewer, Object e1, Object e2) {
+		return extractSortString(e1).compareTo(extractSortString(e2));
+	}
+	
+	private String extractSortString(Object o) {
+		if (o instanceof TreeNodeWrapper) {
+			TreeNodeWrapper t = (TreeNodeWrapper)o;
+			o = t.getObject();
+			if (o == null)
+				return (t.getLabel() != null ? t.getLabel() : t.toString());
+		}
+		if (o == null) return "";
+		if (o instanceof BTSUser) {
+			BTSUser u = (BTSUser)o;
+			return u.getSureName() + ", " + u.getForeName()+" "+u.getUserName();
+		}
+		if (o instanceof BTSUserGroup)
+			return ((BTSUserGroup)o).getName();
+		if (o instanceof BTSProjectDBCollection)
+			return ((BTSProjectDBCollection)o).getCollectionName();
+		if (o instanceof BTSDBCollectionRoleDesc)
+			return ((BTSDBCollectionRoleDesc)o).getRoleName();
+		if (o instanceof BTSProject)
+			return ((BTSProject)o).getName();		
+		return o.toString();
+	}
+	
+}

--- a/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/viewerSorter/BTSUserManagerViewerComparator.java
+++ b/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/viewerSorter/BTSUserManagerViewerComparator.java
@@ -8,17 +8,17 @@ import org.bbaw.bts.btsmodel.BTSUserGroup;
 import org.bbaw.bts.btsviewmodel.TreeNodeWrapper;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerComparator;
-import org.eclipse.jface.viewers.ViewerSorter;
 
-public class BTSUserByNameViewerComparator extends ViewerComparator {
+public class BTSUserManagerViewerComparator extends ViewerComparator {
 
 	@Override
 	public int compare(Viewer viewer, Object e1, Object e2) {
-		return extractSortString(e1).compareTo(extractSortString(e2));
+		return pickSortString(e1).compareTo(pickSortString(e2));
 	}
 	
-	private String extractSortString(Object o) {
+	private String pickSortString(Object o) {
 		if (o instanceof TreeNodeWrapper) {
+			// extract object from container
 			TreeNodeWrapper t = (TreeNodeWrapper)o;
 			o = t.getObject();
 			if (o == null)

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
@@ -40,7 +40,7 @@ import org.bbaw.bts.ui.commons.utils.BTSUIConstants;
 import org.bbaw.bts.ui.commons.validator.StringEmailAddressValidator;
 import org.bbaw.bts.ui.commons.validator.StringHttp_s_URLValidator;
 import org.bbaw.bts.ui.commons.validator.StringNotEmptyValidator;
-import org.bbaw.bts.ui.commons.viewerSorter.BTSUserByNameViewerComparator;
+import org.bbaw.bts.ui.commons.viewerSorter.BTSUserManagerViewerComparator;
 import org.bbaw.bts.ui.main.dialogs.ObjectUpdaterReaderEditorDialog;
 import org.bbaw.bts.ui.main.handlers.CreateNewUserGroupHandler;
 import org.bbaw.bts.ui.main.parts.userMan.support.ProjectDBCollectionTreeFactory;
@@ -760,7 +760,7 @@ public class UserManagementPart
 		};
 
 		treeViewer.addSelectionChangedListener(user_selectionListener);
-		treeViewer.setComparator(new BTSUserByNameViewerComparator());
+		treeViewer.setComparator(new BTSUserManagerViewerComparator());
 		
 		// Create sample data
 		try {
@@ -932,7 +932,7 @@ public class UserManagementPart
 		};
 
 		user_treeViewer.addSelectionChangedListener(user_selectionListener);
-		user_treeViewer.setComparator(new BTSUserByNameViewerComparator());
+		user_treeViewer.setComparator(new BTSUserManagerViewerComparator());
 		// Create sample data
 		userGroups = new ArrayList<BTSUserGroup>();
 		Job job = new Job("load orphans") {
@@ -1085,7 +1085,7 @@ public class UserManagementPart
 		};
 
 		roles_treeViewer.addSelectionChangedListener(roles_selectionListener);
-		roles_treeViewer.setComparator(new BTSUserByNameViewerComparator());
+		roles_treeViewer.setComparator(new BTSUserManagerViewerComparator());
 		// Create sample data
 		projects = projectController.listProjects(null);
 

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
@@ -40,7 +40,7 @@ import org.bbaw.bts.ui.commons.utils.BTSUIConstants;
 import org.bbaw.bts.ui.commons.validator.StringEmailAddressValidator;
 import org.bbaw.bts.ui.commons.validator.StringHttp_s_URLValidator;
 import org.bbaw.bts.ui.commons.validator.StringNotEmptyValidator;
-import org.bbaw.bts.ui.commons.viewerSorter.BTSObjectByNameViewerSorter;
+import org.bbaw.bts.ui.commons.viewerSorter.BTSUserByNameViewerComparator;
 import org.bbaw.bts.ui.main.dialogs.ObjectUpdaterReaderEditorDialog;
 import org.bbaw.bts.ui.main.handlers.CreateNewUserGroupHandler;
 import org.bbaw.bts.ui.main.parts.userMan.support.ProjectDBCollectionTreeFactory;
@@ -99,18 +99,14 @@ import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.jface.viewers.ViewerFilter;
-import org.eclipse.jface.viewers.ViewerSorter;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabFolder;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.custom.SashForm;
-import org.eclipse.swt.events.KeyAdapter;
-import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.layout.FillLayout;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -764,9 +760,7 @@ public class UserManagementPart
 		};
 
 		treeViewer.addSelectionChangedListener(user_selectionListener);
-		treeViewer.setSorter(new ViewerSorter()
-		{
-		});
+		treeViewer.setComparator(new BTSUserByNameViewerComparator());
 		
 		// Create sample data
 		try {
@@ -938,7 +932,7 @@ public class UserManagementPart
 		};
 
 		user_treeViewer.addSelectionChangedListener(user_selectionListener);
-		user_treeViewer.setSorter(new BTSObjectByNameViewerSorter());
+		user_treeViewer.setComparator(new BTSUserByNameViewerComparator());
 		// Create sample data
 		userGroups = new ArrayList<BTSUserGroup>();
 		Job job = new Job("load orphans") {
@@ -1094,9 +1088,7 @@ public class UserManagementPart
 		};
 
 		roles_treeViewer.addSelectionChangedListener(roles_selectionListener);
-		roles_treeViewer.setSorter(new ViewerSorter()
-		{
-		});
+		roles_treeViewer.setComparator(new BTSUserByNameViewerComparator());
 		// Create sample data
 		projects = projectController.listProjects(null);
 


### PR DESCRIPTION
Added a `ViewerComparator` that attempts to handle all types of objects that occur in User Manager dialog viewers. Also don't load node children multiple times in selection listener.