### PR TITLE
Annotation Part filter & startup.

### DIFF
--- a/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/AnnotationPartControllerImpl.java
+++ b/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/AnnotationPartControllerImpl.java
@@ -22,6 +22,7 @@ import org.bbaw.bts.corpus.btsCorpusModel.BTSAnnotation;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSCorpusObject;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSLemmaEntry;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSThsEntry;
+import org.bbaw.bts.corpus.btsCorpusModel.BtsCorpusModelFactory;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.emf.ecore.util.EcoreUtil;

--- a/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/utils/BTSUIConstants.java
+++ b/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/utils/BTSUIConstants.java
@@ -203,7 +203,7 @@ public class BTSUIConstants {
 
 	public static final String EVENT_EGY_TEXT_EDITOR_LOAD_LEMMATA = "event_egy_text_editor_load_lemmata/load";
 	
-	public static final String EVENT_EGY_TEXT_EDITOR_TEXT_REQUESTED = "event_egy_text_editor_text_requested/translation_part";
+	public static final String EVENT_EGY_TEXT_EDITOR_INPUT_REQUESTED = "event_egy_text_editor_input_requested/";
 
 	public static final Color COLOR_ERROR = _resources.createColor(new RGB(255, 0, 0));
 

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -2772,11 +2772,27 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 	@Inject
 	@Optional
 	void eventReceivedTextRequested(
-			@UIEventTopic("event_egy_text_editor_text_requested/*") final BTSText current) {
+			@UIEventTopic(BTSUIConstants.EVENT_EGY_TEXT_EDITOR_INPUT_REQUESTED+"translation_part") final BTSText current) {
 		if (current == null || !current.equals(text)) 
 			if (text != null)
 				selectionService.setSelection(text);
 	}
+
+	@Inject
+	@Optional
+	void eventReceivedRelatedObjectsRequested(
+			@UIEventTopic(BTSUIConstants.EVENT_EGY_TEXT_EDITOR_INPUT_REQUESTED+"annotations_part") final BTSRelatingObjectsLoadingEvent e) {
+		if (e == null)
+			if (text != null) {
+				BTSRelatingObjectsLoadingEvent event = new BTSRelatingObjectsLoadingEvent(
+						text);
+				event.setRelatingObjects(relatingObjects);
+				eventBroker
+						.post(BTSUIConstants.EVENT_TEXT_RELATING_OBJECTS_LOADED,
+								event);
+			}
+	}
+
 
 	/**
 	 * Event received load lemmata.

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextTranslationPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextTranslationPart.java
@@ -201,7 +201,7 @@ public class EgyTextTranslationPart {
 		{
 			loadInput(text);
 		} else
-			eventBroker.post(BTSUIConstants.EVENT_EGY_TEXT_EDITOR_TEXT_REQUESTED, text);
+			eventBroker.post(BTSUIConstants.EVENT_EGY_TEXT_EDITOR_INPUT_REQUESTED+"translation_part", text);
 			
 	}
 	

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
@@ -233,8 +233,11 @@ public class AnnotationsPart implements EventHandler {
 				submenu.setToBeRendered(false);
 			// populate menu items for annotation types
 			// retrieve configuration elements for object type annotation
-			BTSConfigItem typeConf = annotationPartController.getAnnoTypesConfigItem(); 
-			if (!typeConf.getChildren().isEmpty()) {
+			BTSConfigItem typeConf = null;
+			try {
+				typeConf = annotationPartController.getAnnoTypesConfigItem();
+			} catch (Exception e){};
+			if (typeConf != null && !typeConf.getChildren().isEmpty()) {
 				// initialize submenu for annotation types
 				submenu = MMenuFactory.INSTANCE.createMenu();
 				submenu.setElementId("org.bbaw.bts.ui.corpus.part.annotations.viewmenu.show.annotation.type");
@@ -245,13 +248,18 @@ public class AnnotationsPart implements EventHandler {
 						BTSConfigItem confItem = (BTSConfigItem)c;
 						MMenuElement menuItemType = null;
 						// retrieve subtype definition from configuration node
-						BTSConfigItem subtypeConf = annotationPartController.getAnnoSubtypesConfigItem(confItem); 
+						BTSConfigItem subtypeConf = null;
+						try {
+							subtypeConf = annotationPartController.getAnnoSubtypesConfigItem(confItem);
+						} catch (Exception e){};
 						List<BTSConfigItem> subTypeConfItems = new Vector<BTSConfigItem>();
-						// filter attached subtype definition nodes
-						for (BTSConfig cc : subtypeConf.getChildren())
-							if (cc instanceof BTSConfigItem)
-								if (((BTSConfigItem)cc).getValue() != null)
-									subTypeConfItems.add((BTSConfigItem)cc);
+						if (subtypeConf != null) {
+							// filter attached subtype definition nodes
+							for (BTSConfig cc : subtypeConf.getChildren())
+								if (cc instanceof BTSConfigItem)
+									if (((BTSConfigItem)cc).getValue() != null)
+										subTypeConfItems.add((BTSConfigItem)cc);
+						}
 						// if subtypes definitions exist, nest in submenu
 						if (!subTypeConfItems.isEmpty()) {
 							menuItemType = MMenuFactory.INSTANCE.createMenu();

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
@@ -104,8 +104,6 @@ public class AnnotationsPart implements EventHandler {
 
 	private Map<BTSObject, RelatedObjectGroup> objectWidgetMap = new HashMap<BTSObject, RelatedObjectGroup>();
 
-	private List<RelatedObjectGroup> selectedGroups = new Vector<RelatedObjectGroup>(2);
-
 	private List<RelatedObjectGroup> internalSelectedGroup = new Vector<RelatedObjectGroup>(2);
 
 	private BTSTextSelectionEvent textSelectionEvent;
@@ -134,7 +132,7 @@ public class AnnotationsPart implements EventHandler {
 
 	@Inject
 	public AnnotationsPart() {
-		//TODO Your code here
+		//
 	}
 
 	@PostConstruct
@@ -688,9 +686,12 @@ public class AnnotationsPart implements EventHandler {
 		{
 			setSelectedInternal(null, false);
 		}
-		if (objects instanceof List<?> && !((List) objects).isEmpty())
+		if (objects instanceof List<?>)
 		{
-			List<BTSObject> os = (List<BTSObject>) objects;
+			List<BTSObject> os = new Vector<BTSObject>();
+			for (Object o : (List<?>)objects)
+				if (o instanceof BTSObject)
+					os.add((BTSObject)o);
 			os = filterAndCutRelatingObjects(os, null);
 			List<RelatedObjectGroup> groups = new Vector<RelatedObjectGroup>(os.size());
 			boolean resizeRequired = false;

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
@@ -203,8 +203,9 @@ public class AnnotationsPart implements EventHandler {
 		extendAnnotationsFilterMenu();
 
 		scrollComposite.setContent(composite);
-		eventBroker.subscribe("event_text_relating_objects/*", this);
 		constructed = true;
+		// request input from text editor
+		eventBroker.post(BTSUIConstants.EVENT_EGY_TEXT_EDITOR_INPUT_REQUESTED+"annotations_part", relatingObjectsEvent);
 	}
 
 

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/handlers/OpenPartHandler.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/handlers/OpenPartHandler.java
@@ -13,7 +13,7 @@ public class OpenPartHandler {
 		MPart part = partService.findPart(partId);
 		if (part == null)
 		{
-			partService.createPart(partId);
+			part = partService.createPart(partId);
 		}
 		partService.activate(part);
 	}


### PR DESCRIPTION
This is a follow-up [*and fix*] of PR #24. Several problems are fixed hereby that are caused by the Annotation Part being closed, re-opened, or being not currently opened or failing during text editor input processing.

The configuration-based menu generation introduced by PR #24 is performed repeatedly. This fortunately could be fixed, [*even though the necessary E4 app model operations seem inconsistent and had to be found by trial and error.*]

On creation, Annotation should not fail anymore like it could under rare circumstances as of #24, caused by configuration processing errors.

Additionally, Annotation Part now automatically requests the text editor's contents on creation, just like the Translation Editor does as of PR #17 [see 917bc6321c1189822bd9440c3aa8c113d29d6218]. So Annotation Part won't be empty when its only opened *after* a text has been loaded into text editor.

This should make it safe to open, close and use the Annotation Part with the new features at any time.
