### PR TITLE
Disable 'change password' command unless logged in as admin.

### DIFF
--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/handlers/OpenChangePasswordDialogHandler.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/handlers/OpenChangePasswordDialogHandler.java
@@ -4,12 +4,15 @@ package org.bbaw.bts.ui.main.handlers;
 import javax.inject.Named;
 
 import org.bbaw.bts.btsmodel.BTSUser;
+import org.bbaw.bts.core.commons.BTSCoreConstants;
 import org.bbaw.bts.core.controller.generalController.BTSUserController;
 import org.bbaw.bts.ui.main.dialogs.PasswordChangeDialog;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.core.di.annotations.CanExecute;
 import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.di.annotations.Optional;
+import org.eclipse.swt.SWT;
 
 public class OpenChangePasswordDialogHandler {
 	@Execute
@@ -25,9 +28,14 @@ public class OpenChangePasswordDialogHandler {
 		PasswordChangeDialog dialog = ContextInjectionFactory.make(PasswordChangeDialog.class, child);
 		//		context.set(UserManagementDialog.class, dialog);
 
-		if (dialog.open() == dialog.OK)
+		if (dialog.open() == SWT.OK)
 		{
 		}
 	}
-		
+
+	@CanExecute
+	public boolean canExecute(
+			@Optional @Named(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT_USERS) Boolean mayEdit) {
+		return (mayEdit != null && mayEdit.booleanValue());
+	}
 }


### PR DESCRIPTION
Because there are some issues regarding user object propagation, this
option should temporarily be disabled for users without admin rights.