### PR TITLE
Re: Include manual as PDF.

### DIFF
--- a/org.bbaw.bts.core.commons.corpus.help/.classpath
+++ b/org.bbaw.bts.core.commons.corpus.help/.classpath
@@ -1,8 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry exported="true" kind="lib" path="resources/"/>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="src" output="target/classes" path="src">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/org.bbaw.bts.core.commons.corpus.help/.classpath
+++ b/org.bbaw.bts.core.commons.corpus.help/.classpath
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="resources/"/>
+	<classpathentry kind="lib" path="resources/"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" output="target/classes" path="src">
+	<classpathentry kind="src" path="src">
 		<attributes>
 			<attribute name="optional" value="true"/>
 			<attribute name="maven.pomderived" value="true"/>
@@ -18,5 +18,5 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="output" path="target/classes"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.bbaw.bts.core.commons.corpus.help/.settings/org.eclipse.jdt.core.prefs
+++ b/org.bbaw.bts.core.commons.corpus.help/.settings/org.eclipse.jdt.core.prefs
@@ -4,4 +4,5 @@ org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
 org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.source=1.7

--- a/org.bbaw.bts.core.commons.corpus.help/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.commons.corpus.help/META-INF/MANIFEST.MF
@@ -18,6 +18,3 @@ Import-Package: org.bbaw.bts.ui.commons.utils,
  org.eclipse.ui,
  org.osgi.framework;version="1.3.0"
 Bundle-ActivationPolicy: lazy
-Bundle-ClassPath: src/,
- .,
- resources/

--- a/org.bbaw.bts.core.commons.corpus.help/build.properties
+++ b/org.bbaw.bts.core.commons.corpus.help/build.properties
@@ -1,8 +1,8 @@
-output.. = bin/
+source.. = src/
+output.. = bin/,\
+           resources/
 bin.includes = META-INF/,\
                .,\
                fragment.e4xmi,\
                resources/,\
-               src/
-source.. = src/
-src.includes = resources/
+               plugin.xml

--- a/org.bbaw.bts.core.commons.corpus.help/pom.xml
+++ b/org.bbaw.bts.core.commons.corpus.help/pom.xml
@@ -1,0 +1,26 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.bbaw.bts</groupId>
+  <artifactId>org.bbaw.bts.core.commons.corpus.help</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <name>BTS Help Resources Bundle</name>
+  <build>
+    <sourceDirectory>src</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <packaging>eclipse-plugin</packaging>
+  <parent>
+  	<groupId>org.bbaw.bts</groupId>
+  	<artifactId>aaew-bts</artifactId>
+  	<version>1.0.7</version>
+  </parent>
+</project>

--- a/org.bbaw.bts.core.commons.corpus.help/src/org/bbaw/bts/core/commons/corpus/help/OpenPDFManualHandler.java
+++ b/org.bbaw.bts.core.commons.corpus.help/src/org/bbaw/bts/core/commons/corpus/help/OpenPDFManualHandler.java
@@ -3,6 +3,7 @@ package org.bbaw.bts.core.commons.corpus.help;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 
@@ -21,9 +22,12 @@ public class OpenPDFManualHandler {
 		URL url = b.getEntry("resources/BTS.pdf");
 		File file = null;
 		try {
-			file = new File(FileLocator.resolve(url).toURI());
+			URL resolvedURL = FileLocator.toFileURL(url);
+			URI resolvedURI = new URI(resolvedURL.getProtocol(),
+					resolvedURL.getPath(), null); 
+			file = new File(resolvedURI);
 			OpenExternalBrowser.openURL(file.getAbsolutePath());
-		}catch (URISyntaxException | IOException e) {
+		} catch (URISyntaxException | IOException e) {
 			e.printStackTrace();
 			String errMsg = "Could not open document. "+(file != null ? file.getAbsolutePath() : "");
 			MessageDialog md = new MessageDialog(null, "Error", null, errMsg + "\n" + e.toString(),

--- a/org.bbaw.bts.corpus.egy.feature/feature.xml
+++ b/org.bbaw.bts.corpus.egy.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.bbaw.bts.corpus.egy.feature"
       label="EgyCorpusFeature"
-      version="0.0.14.qualifier"
+      version="0.0.15.qualifier"
       provider-name="BBAW">
 
    <description url="http://www.example.com/description">

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
 		<module>org.bbaw.bts.commons.libs.elasticsearch</module>
 		<module>org.bbaw.bts.core.commons</module>
 		<module>org.bbaw.bts.core.commons.corpus</module>
+		<module>org.bbaw.bts.core.commons.corpus.help</module>
 
 		<module>org.bbaw.bts.core.controller</module>
 		<module>org.bbaw.bts.core.controller.impl</module>


### PR DESCRIPTION
Recently added manual-files bundle `org.bbaw.bts.core.commons.help` has been merged containing some flaws. These changes allow for successful resolution and retrieval of bundled files, and bundle inclusion in binary build.