### PR TITLE
Bugfix accidental translation save

### DIFF
--- a/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/widgets/TranslationEditorComposite.java
+++ b/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/widgets/TranslationEditorComposite.java
@@ -156,18 +156,16 @@ public class TranslationEditorComposite extends Composite {
 		this.translations = translations2;
 		this.domain = editingDomain;
 		this.required = required;
+		if (bindingContext == null) {
+			bindingContext = new DataBindingContext();
+		}
 		if (translations == null)
 		{
-			if (binding != null)
-			{
-				// if old translation exists, disconnect and dispose biding
-				binding.dispose();
-			}
 			text.setText("");
 			return;
 		}
 		
-		List ls = translations.getLanguages();
+		List<String> ls = translations.getLanguages();
 		List<String> additionalInputs = new Vector<String>(ls.size());
 		for (Object o : ls) {
 			if (o instanceof String) {
@@ -286,29 +284,33 @@ public class TranslationEditorComposite extends Composite {
 			// BtsmodelPackage.BTS_TRANSLATIONS__TRANSLATIONS, trans);
 			// domain.getCommandStack().execute(command);
 		}
-		if (bindingContext != null) {
-			bindingContext.dispose();
-		}
-		bindingContext = new DataBindingContext();
+	}
 
+	private void databindTranslation(BTSTranslation trans) {
 		EMFUpdateValueStrategy us = null;
 		if (required) {
 			us = new EMFUpdateValueStrategy();
 			us.setBeforeSetValidator(new StringNotEmptyValidator());
 		}
-		binding = bindingContext.bindValue(
-				WidgetProperties.text(SWT.Modify).observeDelayed(
-						BTSUIConstants.DELAY, text),
-				EMFEditProperties.value(domain,
-						BtsmodelPackage.Literals.BTS_TRANSLATION__VALUE)
-						.observe(trans), us, null);
-
-		if (required) {
-			bindingContext.addValidationStatusProvider(binding);
-			BackgroundControlDecorationSupport.create(binding, SWT.TOP
-					| SWT.LEFT);
+		if (binding != null && !binding.isDisposed()) {
+			bindingContext.removeBinding(binding);
+			binding.dispose();
 		}
-
+		if (binding == null || binding.isDisposed()) {
+			binding = bindingContext.bindValue(
+					WidgetProperties.text(SWT.Modify).observeDelayed(
+							BTSUIConstants.DELAY, text),
+					EMFEditProperties.value(domain,
+							BtsmodelPackage.Literals.BTS_TRANSLATION__VALUE)
+							.observe(trans), us, null);
+	
+			if (required) {
+				bindingContext.addValidationStatusProvider(binding);
+				BackgroundControlDecorationSupport.create(binding, SWT.TOP
+						| SWT.LEFT);
+			}
+		}
+		
 	}
 	
 	@Override

--- a/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/widgets/TranslationEditorComposite.java
+++ b/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/widgets/TranslationEditorComposite.java
@@ -357,7 +357,7 @@ public class TranslationEditorComposite extends Composite {
 	
 	public void addLanguageSelectionListener(SelectionListener listener)
 	{
-		if (listener != null && !languageSelectionListeners .contains(listener))
+		if (listener != null && !languageSelectionListeners.contains(listener))
 		{
 			languageSelectionListeners.add(listener);
 		}

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
@@ -1092,7 +1092,9 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 		rect.setLayoutManager(tl);
 		appendFigure(rect);
 
-		word.eAdapters().add(notifier);
+		if (!word.eAdapters().contains(notifier)) {
+			word.eAdapters().add(notifier);
+		}
 		return rect;
 	}
 


### PR DESCRIPTION
EMF data binding was attached to word translation objects, although changes in word translation are obviously meant to be persisted by calling the translation editor's `save()` method instead. Data binding did lead to non-intentionally persisted saves not reflected by the UI.
Data binding has now been removed.

In an additional change, sign text composite is kept from repeatedly attaching its update notifier to the same word objects every time one switches between translit and sign text editor.
