### PR TITLE
Fix error in user group permission management.

### DIFF
--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
@@ -1562,7 +1562,7 @@ public class UserManagementPart
 								BtsmodelPackage.Literals.BTSDB_COLLECTION_ROLE_DESC__CACHED_CHILDREN, tn);
 						compoundCommand.append(command);
 						Command command2 = AddCommand.create(getEditingDomain(selectedDBRoleDesc), selectedDBRoleDesc,
-								BtsmodelPackage.Literals.BTSDB_COLLECTION_ROLE_DESC__USER_ROLES, ug.getName());
+								BtsmodelPackage.Literals.BTSDB_COLLECTION_ROLE_DESC__USER_ROLES, ug.get_id());
 						compoundCommand.append(command2);
 						getEditingDomain(selectedDBRoleDesc).getCommandStack().execute(compoundCommand);
 						manageDirtyObjects(selectedDBRoleDesc, selectedTreeObject);
@@ -1652,7 +1652,7 @@ public class UserManagementPart
 		userGroupMap = new HashMap<String, BTSUserGroup>(groups.size());
 		for (BTSUserGroup u : groups)
 		{
-			userGroupMap.put(u.getName(), u);
+			userGroupMap.put(u.get_id(), u);
 		}
 	}
 


### PR DESCRIPTION
When granting permissions to a group of users, i.e. adding that group to a role like 'guests', that group is apparently inserted into the corresponding `BTSProjectDBCollection` element as well as into the respective collection's `_security` document. Problem was that this wasn't done by adding the user's ID, but instead by putting its _name_ in there. Because of this, during evaluation of a user's access rights, their group memberships couldn't be determined, which affected, amongst others, pull replication and user management GUI.
This problem could however be fixed very easily and I am now embarrassed to have written such a long PR about it.