### PR TITLE
Fix inconsistent permission restrictions in lemma entry/passport editor dialog.

### DIFF
--- a/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
+++ b/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
@@ -572,6 +572,12 @@ public class PermissionsAndExpressionsEvaluationControllerImpl implements
 
 
 	@Override
+	public BTSUser getAuthenticatedUser() {
+		return authenticatedUser;
+	}
+
+
+	@Override
 	public void activateDBCollectionContext(String key) {
 		if (key != null) {
 			String localDBCollContext = null;

--- a/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
+++ b/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
@@ -222,7 +222,7 @@ public class PermissionsAndExpressionsEvaluationControllerImpl implements
 	}
 
 	private void evaluateSelectionPermissionsAndExpressions(Object internalSelection) {
-		evaluateUserContextRole(internalSelection);
+		evaluateUserContextRole();
 
 		evaluateMayAdd(internalSelection);
 		evaluateMayDelete(internalSelection);
@@ -312,6 +312,7 @@ public class PermissionsAndExpressionsEvaluationControllerImpl implements
 		return false;
 	}
 
+	private void evaluateUserContextRole() {
 	private void evaluateUserContextRole(Object internalSelection) {
 		userContextRole = BTSCoreConstants.USER_ROLE_GUESTS;
 		if (authenticatedUser == null || mainProject == null) {

--- a/org.bbaw.bts.core.controller/src/org/bbaw/bts/core/controller/generalController/PermissionsAndExpressionsEvaluationController.java
+++ b/org.bbaw.bts.core.controller/src/org/bbaw/bts/core/controller/generalController/PermissionsAndExpressionsEvaluationController.java
@@ -53,6 +53,12 @@ public interface PermissionsAndExpressionsEvaluationController {
 	 */
 	void activateDBCollectionContext(String prefMainCorpus);
 
+
+	/**
+	 * Retrieve currently logged in {@link BTSUser}.
+	 */
+	BTSUser getAuthenticatedUser();
+
 	/**
 	 * Authenticated user is db admin.
 	 *

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/dialogs/LemmaEntryDialog.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/dialogs/LemmaEntryDialog.java
@@ -1,14 +1,17 @@
 package org.bbaw.bts.ui.egy.dialogs;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.bbaw.bts.core.commons.BTSCoreConstants;
+import org.bbaw.bts.core.controller.generalController.PermissionsAndExpressionsEvaluationController;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSCorpusObject;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSLemmaEntry;
 import org.bbaw.bts.ui.corpus.parts.PassportEditorPart;
 import org.bbaw.bts.ui.egy.parts.EgyLemmaEditorPart;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.ui.services.IServiceConstants;
 import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.TitleAreaDialog;
@@ -27,13 +30,21 @@ public class LemmaEntryDialog extends TitleAreaDialog {
 	private IEclipseContext context;
 
 	@Inject
+	private PermissionsAndExpressionsEvaluationController permissionsController;
+
+	@Inject
 	private BTSLemmaEntry selectionObject;
 	
 	private PassportEditorPart passportEditor;
 
 	private EgyLemmaEditorPart lemmaEditor;
 
-	
+	@Inject
+	@Optional
+	@Named(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT)
+	private Boolean userMayEdit;
+
+
 	/**
 	 * Create the dialog.
 	 * @param parentShell
@@ -49,6 +60,7 @@ public class LemmaEntryDialog extends TitleAreaDialog {
 	 */
 	@Override
 	protected Control createDialogArea(Composite parent) {
+		userMayEdit &= permissionsController.userMayEditObject(permissionsController.getAuthenticatedUser(), selectionObject);
 		Composite area = (Composite) super.createDialogArea(parent);
 
 		SashForm sashForm = new SashForm(area, SWT.VERTICAL);
@@ -67,12 +79,10 @@ public class LemmaEntryDialog extends TitleAreaDialog {
 		((GridLayout) lemmaEdComposite.getLayout()).verticalSpacing = 0;
 		IEclipseContext lemmaChild = context.createChild("lemmaEditorDialog");
 		lemmaChild.set(Composite.class, lemmaEdComposite);
-		lemmaChild.set(IServiceConstants.ACTIVE_SELECTION, null);
 
 		lemmaEditor = ContextInjectionFactory.make(
 				EgyLemmaEditorPart.class, lemmaChild);
 		lemmaEditor.setInputObjectDirect(selectionObject);
-		lemmaEditor.setUserMayEdit(false);
 		
 		
 		Composite passportComposite = new Composite(sashForm, SWT.NONE);
@@ -89,7 +99,7 @@ public class LemmaEntryDialog extends TitleAreaDialog {
 		IEclipseContext passportChild = context.createChild("passportEditorDialog");
 		passportChild.set(Composite.class, passportComposite);
 		passportChild.set(IServiceConstants.ACTIVE_SELECTION, null);
-		passportChild.set(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT, new Boolean(false));
+		passportChild.set(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT, new Boolean(userMayEdit));
 
 		passportEditor = ContextInjectionFactory.make(
 				PassportEditorPart.class, passportChild);
@@ -107,6 +117,7 @@ public class LemmaEntryDialog extends TitleAreaDialog {
 	protected void createButtonsForButtonBar(Composite parent) {
 		createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL,
 				true);
+		getButton(IDialogConstants.OK_ID).setEnabled(userMayEdit);
 		createButton(parent, IDialogConstants.CANCEL_ID,
 				IDialogConstants.CANCEL_LABEL, false);
 	}

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/dialogs/LemmaEntryDialog.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/dialogs/LemmaEntryDialog.java
@@ -2,12 +2,11 @@ package org.bbaw.bts.ui.egy.dialogs;
 
 import javax.inject.Inject;
 
-import org.bbaw.bts.btsmodel.BTSObject;
+import org.bbaw.bts.core.commons.BTSCoreConstants;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSCorpusObject;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSLemmaEntry;
 import org.bbaw.bts.ui.corpus.parts.PassportEditorPart;
 import org.bbaw.bts.ui.egy.parts.EgyLemmaEditorPart;
-import org.bbaw.bts.ui.resources.BTSResourceProvider;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
 import org.eclipse.e4.ui.services.IServiceConstants;
@@ -21,7 +20,6 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
-import org.eclipse.swt.widgets.Text;
 
 public class LemmaEntryDialog extends TitleAreaDialog {
 

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/dialogs/LemmaEntryDialog.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/dialogs/LemmaEntryDialog.java
@@ -28,9 +28,12 @@ public class LemmaEntryDialog extends TitleAreaDialog {
 
 	@Inject
 	private BTSLemmaEntry selectionObject;
+	
 	private PassportEditorPart passportEditor;
 
 	private EgyLemmaEditorPart lemmaEditor;
+
+	
 	/**
 	 * Create the dialog.
 	 * @param parentShell
@@ -82,15 +85,16 @@ public class LemmaEntryDialog extends TitleAreaDialog {
 		((GridLayout) passportComposite.getLayout()).marginHeight = 0;
 		((GridLayout) passportComposite.getLayout()).horizontalSpacing = 0;
 		((GridLayout) passportComposite.getLayout()).verticalSpacing = 0;
+
 		IEclipseContext passportChild = context.createChild("passportEditorDialog");
 		passportChild.set(Composite.class, passportComposite);
 		passportChild.set(IServiceConstants.ACTIVE_SELECTION, null);
+		passportChild.set(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT, new Boolean(false));
+
 		passportEditor = ContextInjectionFactory.make(
 				PassportEditorPart.class, passportChild);
 		passportEditor.setInputObjectDirect((BTSCorpusObject) selectionObject);
-//		passportEditor.setUserMayEdit(false);
 
-		
 		sashForm.setWeights(new int[] { 1, 1 });
 		return area;
 	}

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/PassportEditorPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/PassportEditorPart.java
@@ -1084,12 +1084,9 @@ public class PassportEditorPart {
 
 		// scrollComposite.layout();
 
-		CompoundIdentifiersEditorComposite relationsEditor = ContextInjectionFactory
+		ContextInjectionFactory
 				.make(CompoundIdentifiersEditorComposite.class, child);
 
-		// foreach relation in object.relations
-		// make relation widget
-		// add plus and minus button
 	}
 
 	private CommandStackListener getCommandStackListener() {

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/widgets/CompoundIdentifiersEditorComposite.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/widgets/CompoundIdentifiersEditorComposite.java
@@ -81,7 +81,6 @@ public class CompoundIdentifiersEditorComposite extends Composite {
 	}
 
 	private void createWidgets() {
-		// if (corpusObject.getRelations() )
 		if (!object.getExternalReferences().isEmpty())
 		{
 			for (int i = 0; i < object.getExternalReferences().size(); i++) {
@@ -201,7 +200,7 @@ public class CompoundIdentifiersEditorComposite extends Composite {
 
 		child.set(BTSObject.class, object);
 		child.set(BTSResourceProvider.class, resourceProvider);
-		IdentifierEditorComposite editor = ContextInjectionFactory.make(
+		ContextInjectionFactory.make(
 				IdentifierEditorComposite.class, child);
 		// relationMap.put(relationConfig, composite);
 

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/widgets/IdentifierEditorComposite.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/widgets/IdentifierEditorComposite.java
@@ -265,6 +265,7 @@ public class IdentifierEditorComposite extends Composite {
 		if (loaded && !this.isDisposed())
 		{
 			referenceText.setEditable(mayEdit);
+			typeText.setEditable(mayEdit);
 			selectComboViewer.getCombo().setEnabled(mayEdit);
 		}
 		

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/widgets/IdentifierEditorComposite.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/widgets/IdentifierEditorComposite.java
@@ -129,7 +129,7 @@ public class IdentifierEditorComposite extends Composite {
 	}
 
 	@PostConstruct
-	public void postContstruct() {
+	public void postConstruct() {
 
 		loadInput(itemConfig);
 


### PR DESCRIPTION
**Problem**: GUI for editing single wordlist lemma entries does not correctly reflect a user's permissions to modify the loaded object. Regardless of actual permission, any user can make changes and close editor dialog by clicking its `OK` button, thereby saving made changes. This happens because `LemmaEntryDialog` and `PassportEditorPart` don't know about the user's permissions on the object in question, because its selection is not being broadcasted via `ESelectionService` and hence goes unnoticed by the permission controller.

**Solution**: Notification of permission controller about a selected lemma entry object doesn't work like expected in this case, because of multiple side effects of a changed `ACTIVE_SELECTION`. Instead, permissions editor is equiped with a new public method `getAuthenticatedUser`, which returns the current `BTSUser` to the lemma entry editor dialog, so that it can check for their permissions on the lemma object to be loaded by calling `userMayEditObject`. Then, GUI widgets are disabled accordingly (including OK button and identifier type textbox).

