### PR TITLE
Fix unlabeled user group bug in user management editor.

### DIFF
--- a/org.bbaw.bts.core.services.impl/src/org/bbaw/bts/core/services/impl/services/BTSEvaluationServiceImpl.java
+++ b/org.bbaw.bts.core.services.impl/src/org/bbaw/bts/core/services/impl/services/BTSEvaluationServiceImpl.java
@@ -360,11 +360,9 @@ public class BTSEvaluationServiceImpl implements BTSEvaluationService
 					|| userId.equals(authenticatedUser.getUserName())) {
 				return true;
 			}
-			if (userGroups != null && !userGroups.isEmpty()) {
-				for (BTSUserGroup g : userGroups) {
-					if (userId.equals(g.get_id()) || userId.equals(g.getName())) {
-						return true;
-					}
+			if (authenticatedUser.getGroupIds() != null && !authenticatedUser.getGroupIds().isEmpty()) {
+				if (authenticatedUser.getGroupIds().contains(userId)) {
+					return true;
 				}
 			}
 

--- a/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/viewerSorter/BTSUserManagerViewerComparator.java
+++ b/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/viewerSorter/BTSUserManagerViewerComparator.java
@@ -13,7 +13,18 @@ public class BTSUserManagerViewerComparator extends ViewerComparator {
 
 	@Override
 	public int compare(Viewer viewer, Object e1, Object e2) {
-		return pickSortString(e1).compareTo(pickSortString(e2));
+		String s1 = pickSortString(e1);
+		if (s1 != null) {
+			String s2 = pickSortString(e2);
+			if (s2 != null) {
+				return s1.compareTo(s2);
+			}
+			return -1;
+		}
+		if (pickSortString(e2) != null) {
+			return 1;
+		}
+		return 0;
 	}
 	
 	private String pickSortString(Object o) {

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
@@ -876,7 +876,7 @@ public class UserManagementPart
 			dialogTitle = "Delete Usergroup";
 			dialogMessage = "Delete selected usergroup: " + labelProvider.getText(object);
 		}
-		if (!permissionController.authenticatedUserMayDeleteUserOrUserGroup((BTSObject)object))
+		if (!permissionController.userMayEditObject(permissionController.getAuthenticatedUser(), (BTSObject)object))
 		{
 			dialogTitle = "Deletion Not Allowed";
 			dialogMessage = "You are not allowed to delete the selected user or usergroup: " + labelProvider.getText(object);

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
@@ -2632,6 +2632,7 @@ public class UserManagementPart
 				TreeNodeWrapper tn = wrappObject(object);
 				tn.setParent(user_root);
 				user_root.getChildren().add(tn);
+				StructuredSelection select = new StructuredSelection(tn);
 				handleUserTreeSelection((IStructuredSelection) select, user_treeViewer);
 				if (object instanceof BTSUserGroup)
 				{
@@ -2641,7 +2642,7 @@ public class UserManagementPart
 					observableLisAllUserGroups.add(object);
 					dirtyUserGroups.add((BTSUserGroup) object);
 				}
-				user_treeViewer.setSelection(new StructuredSelection(tn), true);
+				user_treeViewer.setSelection(select);
 			}
 		});
 

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
@@ -2632,6 +2632,7 @@ public class UserManagementPart
 				TreeNodeWrapper tn = wrappObject(object);
 				tn.setParent(user_root);
 				user_root.getChildren().add(tn);
+				handleUserTreeSelection((IStructuredSelection) select, user_treeViewer);
 				if (object instanceof BTSUserGroup)
 				{
 					if (observableLisAllUserGroups == null) {

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
@@ -437,6 +437,7 @@ public class UserManagementPart
 		user_ToolDeleteGroup.setToolTipText("Delete");
 		user_ToolDeleteGroup.setImage(resourceProvider.getImage(
 				Display.getDefault(), BTSResourceProvider.IMG_DELETE));
+		user_ToolDeleteGroup.setEnabled(false);
 		user_ToolDeleteGroup.addSelectionListener(new SelectionAdapter()
 		{
 
@@ -1123,6 +1124,7 @@ public class UserManagementPart
 
 	private void handleUserTreeSelection(IStructuredSelection selection2, TreeViewer treeViewer)
 	{
+		user_ToolDeleteGroup.setEnabled(false);
 		if (selection2.getFirstElement() instanceof TreeNodeWrapper)
 		{
 			TreeNodeWrapper tn = (TreeNodeWrapper) selection2.getFirstElement();
@@ -1136,6 +1138,7 @@ public class UserManagementPart
 					loadChildren(parents, treeViewer, false);
 				}
 				selectedGroup = (BTSUserGroup) tn.getObject();
+				user_ToolDeleteGroup.setEnabled(true);
 				loadGroupEditComposite(selectedGroup);
 				enableUndoRedo(selectedTreeObject);
 			}

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/UserManagementPart.java
@@ -1114,9 +1114,11 @@ public class UserManagementPart
 		{
 			public void run()
 			{
-				treeviewer.removeSelectionChangedListener(user_selectionListener);
-				treeviewer.refresh();
-				treeviewer.addSelectionChangedListener(user_selectionListener);
+				if (!treeviewer.getTree().isDisposed()) {
+					treeviewer.removeSelectionChangedListener(user_selectionListener);
+					treeviewer.refresh();
+					treeviewer.addSelectionChangedListener(user_selectionListener);
+				}
 			}
 		});
 
@@ -1124,7 +1126,9 @@ public class UserManagementPart
 
 	private void handleUserTreeSelection(IStructuredSelection selection2, TreeViewer treeViewer)
 	{
-		user_ToolDeleteGroup.setEnabled(false);
+		if (!user_ToolDeleteGroup.isDisposed()) {
+			user_ToolDeleteGroup.setEnabled(false);
+		}
 		if (selection2.getFirstElement() instanceof TreeNodeWrapper)
 		{
 			TreeNodeWrapper tn = (TreeNodeWrapper) selection2.getFirstElement();
@@ -1138,7 +1142,9 @@ public class UserManagementPart
 					loadChildren(parents, treeViewer, false);
 				}
 				selectedGroup = (BTSUserGroup) tn.getObject();
-				user_ToolDeleteGroup.setEnabled(true);
+				if (!user_ToolDeleteGroup.isDisposed()) {
+					user_ToolDeleteGroup.setEnabled(true);
+				}
 				loadGroupEditComposite(selectedGroup);
 				enableUndoRedo(selectedTreeObject);
 			}
@@ -2326,8 +2332,13 @@ public class UserManagementPart
 		{
 			loadAllUsers();
 		}
-		composite_right.dispose();
+		if (composite_right != null && !composite_right.isDisposed()) {
+			composite_right.dispose();
+		}
 		composite_right = null;
+		if (user_sashForm.isDisposed()) {
+			return null;
+		}
 		composite_right = new Composite(user_sashForm, SWT.NONE);
 		composite_right.setLayout(new FillLayout(SWT.HORIZONTAL));
 
@@ -2645,7 +2656,6 @@ public class UserManagementPart
 					observableLisAllUserGroups.add(object);
 					dirtyUserGroups.add((BTSUserGroup) object);
 				}
-				user_treeViewer.setSelection(select);
 			}
 		});
 


### PR DESCRIPTION
Problem: comparator used in user group tree widget fails whenever a user group without label is to be displayed. This means that newly created user groups will not be displayed, because they ain't labeled yet. Furthermore, after closing and reopening the user management editor, no groups are shown at all due to the failing comparisons.

Solution: Comparator is fixed and doesn't fail on unlabeled groups anymore. Also, when creating a group, its properties are loaded into the corresponding UI controls so that a user can tell that the group must be labeled.

In addition, a small bug has been fixed that prevented an admin from deleting a user group.