### PR TITLE
Prevent unauthorized users from making changes in readers/updaters editor dialog.

### DIFF
--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/dialogs/ObjectUpdaterReaderEditorDialog.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/dialogs/ObjectUpdaterReaderEditorDialog.java
@@ -4,6 +4,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.bbaw.bts.btsmodel.BTSDBBaseObject;
+import org.bbaw.bts.core.commons.BTSCoreConstants;
 import org.bbaw.bts.ui.main.parts.ObjectUpdaterReaderEditorPart;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
@@ -139,6 +140,7 @@ public class ObjectUpdaterReaderEditorDialog extends TitleAreaDialog {
 			}
 		}
 
+		button.setEnabled((Boolean)context.get(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT));
 		setButtonLayoutData(button);
 		return button;
 

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/handlers/OpenUpdatersReadersEditorDialogHandler.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/handlers/OpenUpdatersReadersEditorDialogHandler.java
@@ -4,6 +4,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.bbaw.bts.btsmodel.BTSDBBaseObject;
+import org.bbaw.bts.core.commons.BTSCoreConstants;
 import org.bbaw.bts.core.controller.generalController.PermissionsAndExpressionsEvaluationController;
 import org.bbaw.bts.ui.main.dialogs.ObjectUpdaterReaderEditorDialog;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
@@ -23,13 +24,16 @@ public class OpenUpdatersReadersEditorDialogHandler {
 	@Execute
 	public void execute(
 			@Named(IServiceConstants.ACTIVE_SHELL) final Shell shell,
+			@Named(IServiceConstants.ACTIVE_SELECTION) final BTSDBBaseObject selection,
 			IEclipseContext context) {
+		IEclipseContext childContext = context.createChild("Edit Updaters/Readers Context");
+		childContext.set(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT, 
+				new Boolean(permissionsController.userMayEditObject(
+						permissionsController.getAuthenticatedUser(), selection)));
 		ObjectUpdaterReaderEditorDialog dialog = ContextInjectionFactory.make(
-				ObjectUpdaterReaderEditorDialog.class, context);
-		// context.set(UserManagementDialog.class, dialog);
-
-		if (dialog.open() == dialog.OK) {
-		}
+				ObjectUpdaterReaderEditorDialog.class, childContext);
+		childContext.set(ObjectUpdaterReaderEditorDialog.class, dialog);
+		dialog.open();
 	}
 
 	@CanExecute

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/handlers/OpenUpdatersReadersEditorDialogHandler.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/handlers/OpenUpdatersReadersEditorDialogHandler.java
@@ -1,9 +1,10 @@
 package org.bbaw.bts.ui.main.handlers;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.bbaw.bts.btsmodel.BTSDBBaseObject;
-import org.bbaw.bts.core.commons.BTSCoreConstants;
+import org.bbaw.bts.core.controller.generalController.PermissionsAndExpressionsEvaluationController;
 import org.bbaw.bts.ui.main.dialogs.ObjectUpdaterReaderEditorDialog;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
@@ -15,6 +16,9 @@ import org.eclipse.swt.widgets.Shell;
 
 public class OpenUpdatersReadersEditorDialogHandler {
 
+	@Inject
+	private PermissionsAndExpressionsEvaluationController permissionsController;
+	
 	@Optional
 	@Execute
 	public void execute(
@@ -30,11 +34,9 @@ public class OpenUpdatersReadersEditorDialogHandler {
 
 	@CanExecute
 	public boolean canExecute(
-			@Optional @Named(IServiceConstants.ACTIVE_SELECTION) BTSDBBaseObject selection,
-			@Optional @Named(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT) Boolean mayEdit) {
-		if (mayEdit != null && mayEdit.booleanValue())
-		{
-			return selection != null;
+			@Optional @Named(IServiceConstants.ACTIVE_SELECTION) BTSDBBaseObject selection) {
+		if (selection != null) {
+			return permissionsController.userMayEditObject(permissionsController.getAuthenticatedUser(), selection);
 		}
 		return false;
 	}

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/handlers/OpenUserManagerHandler.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/handlers/OpenUserManagerHandler.java
@@ -2,7 +2,6 @@ package org.bbaw.bts.ui.main.handlers;
 
 import javax.inject.Named;
 
-import org.bbaw.bts.btsmodel.BTSDBBaseObject;
 import org.bbaw.bts.core.commons.BTSCoreConstants;
 import org.bbaw.bts.ui.main.dialogs.UserManagementDialog;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
@@ -20,11 +19,7 @@ public class OpenUserManagerHandler
 	public void execute(@Named(IServiceConstants.ACTIVE_SHELL) final Shell shell, IEclipseContext context)
 	{
 		UserManagementDialog dialog = ContextInjectionFactory.make(UserManagementDialog.class, context);
-		//		context.set(UserManagementDialog.class, dialog);
-
-		if (dialog.open() == dialog.OK)
-		{
-		}
+		dialog.open();
 	}
 
 	@CanExecute

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/ObjectUpdaterReaderEditorPart.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/parts/ObjectUpdaterReaderEditorPart.java
@@ -1,6 +1,5 @@
 package org.bbaw.bts.ui.main.parts;
 
-import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Vector;
@@ -25,10 +24,6 @@ import org.bbaw.bts.ui.commons.viewerSorter.BTSUserManagerViewerComparator;
 import org.bbaw.bts.ui.resources.BTSResourceProvider;
 import org.eclipse.core.databinding.observable.Realm;
 import org.eclipse.core.databinding.observable.list.WritableList;
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.e4.core.contexts.Active;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.ui.di.UISynchronize;
@@ -43,8 +38,6 @@ import org.eclipse.emf.edit.ui.provider.AdapterFactoryContentProvider;
 import org.eclipse.emf.edit.ui.provider.AdapterFactoryLabelProvider;
 import org.eclipse.jface.databinding.swt.SWTObservables;
 import org.eclipse.jface.databinding.viewers.ObservableListContentProvider;
-import org.eclipse.jface.dialogs.ProgressMonitorDialog;
-import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.IStructuredSelection;


### PR DESCRIPTION
Unauthorized users are no longer allowed to open the 'edit updaters/readers dialog'. 