### PR TITLE
Support additional translation languages in STE and Prefs page.

### DIFF
--- a/org.bbaw.bts.ui.commons.corpus/src/org/bbaw/bts/ui/commons/corpus/util/BTSEGYUIConstants.java
+++ b/org.bbaw.bts.ui.commons.corpus/src/org/bbaw/bts/ui/commons/corpus/util/BTSEGYUIConstants.java
@@ -57,6 +57,8 @@ public class BTSEGYUIConstants {
 	public static final String SIGN_TEXT_SHOW_TRANSLATION_EN = "sign-text-editor_show_translation_en";
 	public static final String SIGN_TEXT_SHOW_TRANSLATION_FR = "sign-text-editor_show_translation_fr";
 	public static final String SIGN_TEXT_SHOW_TRANSLATION_ES = "sign-text-editor_show_translation_es";
+	public static final String SIGN_TEXT_SHOW_TRANSLATION_AR = "sign-text-editor_show_translation_ar";
+	public static final String SIGN_TEXT_SHOW_TRANSLATION_IT = "sign-text-editor_show_translation_it";
 	public static final String SIGN_TEXT_SHOW_LINE_WIDTH = "sign-text-editor_line_width";
 	public static final String PREF_LEMMATIZER_FELXION_DEFAULT = "pref_lemmatizer_flexion_default";
 	public static final String EVENT_CLEAR_TOKEN_DATA = "event_clear_token_data";

--- a/org.bbaw.bts.ui.commons.corpus/src/org/bbaw/bts/ui/commons/corpus/util/BTSEGYUIConstants.java
+++ b/org.bbaw.bts.ui.commons.corpus/src/org/bbaw/bts/ui/commons/corpus/util/BTSEGYUIConstants.java
@@ -1,5 +1,10 @@
 package org.bbaw.bts.ui.commons.corpus.util;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.bbaw.bts.core.commons.BTSCoreConstants;
+
 public class BTSEGYUIConstants {
 
 	
@@ -53,12 +58,14 @@ public class BTSEGYUIConstants {
 	public static final String SIGN_TEXT_SHOW_HIEROGLYPHS = "sign-text-editor_show_hieroglyphs";
 	public static final String SIGN_TEXT_SHOW_LEMMAID = "sign-text-editor_show_lemmaid";
 	public static final String SIGN_TEXT_SHOW_FLEXION = "sign-text-editor_show_flexion";
-	public static final String SIGN_TEXT_SHOW_TRANSLATION_DE = "sign-text-editor_show_translation_de";
-	public static final String SIGN_TEXT_SHOW_TRANSLATION_EN = "sign-text-editor_show_translation_en";
-	public static final String SIGN_TEXT_SHOW_TRANSLATION_FR = "sign-text-editor_show_translation_fr";
-	public static final String SIGN_TEXT_SHOW_TRANSLATION_ES = "sign-text-editor_show_translation_es";
-	public static final String SIGN_TEXT_SHOW_TRANSLATION_AR = "sign-text-editor_show_translation_ar";
-	public static final String SIGN_TEXT_SHOW_TRANSLATION_IT = "sign-text-editor_show_translation_it";
+	public static final String SIGN_TEXT_SHOW_TRANSLATION_PREFNODE_PREFIX = "sign-text-editor_show_translation_"; 
+	public static final Map<String, String> SIGN_TEXT_SHOW_TRANSLATION; 
+	static {
+		SIGN_TEXT_SHOW_TRANSLATION = new HashMap<>();
+		for (String lang : BTSCoreConstants.LANGS) {
+			SIGN_TEXT_SHOW_TRANSLATION.put(lang, SIGN_TEXT_SHOW_TRANSLATION_PREFNODE_PREFIX+lang);
+		}
+	}
 	public static final String SIGN_TEXT_SHOW_LINE_WIDTH = "sign-text-editor_line_width";
 	public static final String PREF_LEMMATIZER_FELXION_DEFAULT = "pref_lemmatizer_flexion_default";
 	public static final String EVENT_CLEAR_TOKEN_DATA = "event_clear_token_data";

--- a/org.bbaw.bts.ui.commons.corpus/src/org/bbaw/bts/ui/commons/corpus/util/BTSEGYUIConstants.java
+++ b/org.bbaw.bts.ui.commons.corpus/src/org/bbaw/bts/ui/commons/corpus/util/BTSEGYUIConstants.java
@@ -58,12 +58,12 @@ public class BTSEGYUIConstants {
 	public static final String SIGN_TEXT_SHOW_HIEROGLYPHS = "sign-text-editor_show_hieroglyphs";
 	public static final String SIGN_TEXT_SHOW_LEMMAID = "sign-text-editor_show_lemmaid";
 	public static final String SIGN_TEXT_SHOW_FLEXION = "sign-text-editor_show_flexion";
-	public static final String SIGN_TEXT_SHOW_TRANSLATION_PREFNODE_PREFIX = "sign-text-editor_show_translation_"; 
+	public static final String SIGN_TEXT_SHOW_TRANSLATION_PREF_PREFIX = "sign-text-editor_show_translation_"; 
 	public static final Map<String, String> SIGN_TEXT_SHOW_TRANSLATION; 
 	static {
 		SIGN_TEXT_SHOW_TRANSLATION = new HashMap<>();
 		for (String lang : BTSCoreConstants.LANGS) {
-			SIGN_TEXT_SHOW_TRANSLATION.put(lang, SIGN_TEXT_SHOW_TRANSLATION_PREFNODE_PREFIX+lang);
+			SIGN_TEXT_SHOW_TRANSLATION.put(lang, SIGN_TEXT_SHOW_TRANSLATION_PREF_PREFIX+lang);
 		}
 	}
 	public static final String SIGN_TEXT_SHOW_LINE_WIDTH = "sign-text-editor_line_width";

--- a/org.bbaw.bts.ui.commons.corpus/src/org/bbaw/bts/ui/commons/corpus/util/BTSEGYUIConstants.java
+++ b/org.bbaw.bts.ui.commons.corpus/src/org/bbaw/bts/ui/commons/corpus/util/BTSEGYUIConstants.java
@@ -61,6 +61,7 @@ public class BTSEGYUIConstants {
 	public static final String SIGN_TEXT_SHOW_TRANSLATION_PREF_PREFIX = "sign-text-editor_show_translation_"; 
 	public static final Map<String, String> SIGN_TEXT_SHOW_TRANSLATION; 
 	static {
+		assert BTSCoreConstants.LANGS.length < Integer.SIZE + 1;
 		SIGN_TEXT_SHOW_TRANSLATION = new HashMap<>();
 		for (String lang : BTSCoreConstants.LANGS) {
 			SIGN_TEXT_SHOW_TRANSLATION.put(lang, SIGN_TEXT_SHOW_TRANSLATION_PREF_PREFIX+lang);

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/preferences/SignTextEditorPage.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/preferences/SignTextEditorPage.java
@@ -1,5 +1,6 @@
 package org.bbaw.bts.ui.egy.preferences;
 
+import org.bbaw.bts.core.commons.BTSCoreConstants;
 import org.bbaw.bts.ui.commons.corpus.util.BTSEGYUIConstants;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.ui.IWorkbench;
@@ -24,12 +25,11 @@ public class SignTextEditorPage extends FieldEditorPreferencePage {
 		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_HIEROGLYPHS, "Show Hieroglyphs", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_LEMMAID, "Show Lemma ID", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_FLEXION, "Show Flexion", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
-		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_DE, "Show Translation: DE", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
-		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_EN, "Show Translation: EN", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
-		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_FR, "Show Translation: FR", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
-		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_ES, "Show Translation: ES", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
-		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_AR, "Show Translation: AR", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
-		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_IT, "Show Translation: IT", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
+		for (String lang : BTSCoreConstants.LANGS) {
+			String prefNode = BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_PREFNODE_PREFIX + lang;
+			addField(new BooleanFieldEditor(prefNode, "Show Translation: "+lang.toUpperCase(),
+					BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
+		}
 		addField(new IntegerFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_LINE_WIDTH, "Line Width in Pixel", getFieldEditorParent()));
 	}
 

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/preferences/SignTextEditorPage.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/preferences/SignTextEditorPage.java
@@ -26,7 +26,7 @@ public class SignTextEditorPage extends FieldEditorPreferencePage {
 		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_LEMMAID, "Show Lemma ID", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_FLEXION, "Show Flexion", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
 		for (String lang : BTSCoreConstants.LANGS) {
-			String prefNode = BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_PREFNODE_PREFIX + lang;
+			String prefNode = BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_PREF_PREFIX + lang;
 			addField(new BooleanFieldEditor(prefNode, "Show Translation: "+lang.toUpperCase(),
 					BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
 		}

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/preferences/SignTextEditorPage.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/preferences/SignTextEditorPage.java
@@ -28,6 +28,8 @@ public class SignTextEditorPage extends FieldEditorPreferencePage {
 		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_EN, "Show Translation: EN", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_FR, "Show Translation: FR", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
 		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_ES, "Show Translation: ES", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
+		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_AR, "Show Translation: AR", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
+		addField(new BooleanFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_IT, "Show Translation: IT", BooleanFieldEditor.DEFAULT, getFieldEditorParent()));
 		addField(new IntegerFieldEditor(BTSEGYUIConstants.SIGN_TEXT_SHOW_LINE_WIDTH, "Line Width in Pixel", getFieldEditorParent()));
 	}
 

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
@@ -1061,7 +1061,7 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 
 		for (int i=0; i<BTSCoreConstants.LANGS.length; i++) {
 			String lang = BTSCoreConstants.LANGS[i];
-			if ((showTransLangMask & 1<<i) == 1<<i) {
+			if ((showTransLangMask>>i & 1) == 1) {
 				addTransToWordFigure(word, rect, lang);
 			}
 		}
@@ -1155,41 +1155,27 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 		
 		BTSWord word = (BTSWord) ((WordFigure)figure).getModelObject();
 
-		int wCharLen  = word.getWChar().length() * 2;
-		if (wCharLen > 2)
-		{
-			len = wCharLen;
-		
+		len = Math.max(len, word.getWChar().length() * 2);
+
 		// if word calculate according to settings!
 		if (showHieroglyphs)
 		{
-			
-			int hieroLen = ((WordFigure)figure).getImageWidth();
-			if (hieroLen > len)
-			{
-				len = hieroLen;
-			}
+			len = Math.max(len, ((WordFigure)figure).getImageWidth());
 		}
 		if (word != null && word.getTranslation() != null && (showTransLangMask != 0))
 		{
+				len = Math.max(len, ((WordFigure)figure).getImageWidth());
 				// determine minimal width required by translation text
-				int transLen = 0;
 				for (int i=0; i<BTSCoreConstants.LANGS.length; i++) {
 					String lang = BTSCoreConstants.LANGS[i];
-					if ((showTransLangMask & 1<<i) == 1<<i) {
+					if ((showTransLangMask>>i & 1) == 1) {
 						String trans = word.getTranslation().getTranslationStrict(lang);
 						if (trans != null)
 						{
-							transLen = trans.length();
+							len = Math.max(len, trans.length() * 2);
 						}
 					}
 				}
-				transLen = transLen * 2; // from chars to pixel length
-				if (transLen > len)
-				{
-					len = transLen;
-				}
-				len = ((WordFigure)figure).getImageWidth();}
 		}
 		return len;
 	}

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
@@ -128,7 +128,7 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 	@Preference(nodePath = "org.bbaw.bts.ui.corpus.egy")
 	IEclipsePreferences preferences;
 
-	private long showTransLangMask = 0;
+	private Integer showTransLangMask = 0;
 
 	@Inject
 	@Preference(value = BTSEGYUIConstants.SIGN_TEXT_SHOW_LINE_WIDTH, nodePath = "org.bbaw.bts.ui.corpus.egy")
@@ -1170,7 +1170,7 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 				len = hieroLen;
 			}
 		}
-		if (word != null && word.getTranslation() != null && (showTransLangMask > 0))
+		if (word != null && word.getTranslation() != null && (showTransLangMask != 0))
 		{
 				// determine minimal width required by translation text
 				int transLen = 0;

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
@@ -137,7 +137,15 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 	@Inject
 	@Preference(value = BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_ES, nodePath = "org.bbaw.bts.ui.corpus.egy")
 	private Boolean showTransES;
-	
+
+	@Inject
+	@Preference(value = BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_AR, nodePath = "org.bbaw.bts.ui.corpus.egy")
+	private Boolean showTransAR;
+
+	@Inject
+	@Preference(value = BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_IT, nodePath = "org.bbaw.bts.ui.corpus.egy")
+	private Boolean showTransIT;
+
 	@Inject
 	@Preference(value = BTSEGYUIConstants.SIGN_TEXT_SHOW_LINE_WIDTH, nodePath = "org.bbaw.bts.ui.corpus.egy")
 	private Integer max_line_length;
@@ -1076,6 +1084,14 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 		{
 			addTransToWordFigure(word, rect, "es");
 		}
+		if (showTransAR)
+		{
+			addTransToWordFigure(word, rect, "ar");
+		}
+		if (showTransIT)
+		{
+			addTransToWordFigure(word, rect, "it");
+		}
 		rect.setSize(90, 290);
 		rect.addFigureListener(new FigureListener() {
 
@@ -1181,7 +1197,7 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 				len = hieroLen;
 			}
 		}
-		if (word != null && word.getTranslation() != null && (showTransDE || showTransEN || showTransES || showTransFR))
+		if (word != null && word.getTranslation() != null && (showTransDE || showTransEN || showTransES || showTransFR || showTransAR || showTransIT))
 		{
 				int transLen = 0;
 				if (showTransDE)
@@ -1211,6 +1227,22 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 				if (showTransFR)
 				{
 					String trans = word.getTranslation().getTranslationStrict("fr");
+					if (trans != null && trans.length() > transLen)
+					{
+						transLen = trans.length();
+					}
+				}
+				if (showTransAR)
+				{
+					String trans = word.getTranslation().getTranslationStrict("ar");
+					if (trans != null && trans.length() > transLen)
+					{
+						transLen = trans.length();
+					}
+				}
+				if (showTransIT)
+				{
+					String trans = word.getTranslation().getTranslationStrict("it");
 					if (trans != null && trans.length() > transLen)
 					{
 						transLen = trans.length();

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
@@ -595,11 +595,11 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 		container.addKeyListener(keyListener);
 
 		// initialize translation languages mask
+		showTransLangMask = 0;
 		for (int i=0; i < BTSCoreConstants.LANGS.length; i++) {
 			String lang = BTSCoreConstants.LANGS[i];
-			String prefNode = BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_PREFNODE_PREFIX + lang;
-			Boolean showTranslation = preferences.getBoolean(prefNode, false);
-			if (showTranslation) {
+			String prefVal = BTSEGYUIConstants.SIGN_TEXT_SHOW_TRANSLATION_PREF_PREFIX + lang;
+			if (preferences.getBoolean(prefVal, false)) {
 				showTransLangMask |= 1<<i;
 			}
 		}
@@ -1061,7 +1061,7 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 
 		for (int i=0; i<BTSCoreConstants.LANGS.length; i++) {
 			String lang = BTSCoreConstants.LANGS[i];
-			if ((showTransLangMask & i) == i) {
+			if ((showTransLangMask & 1<<i) == 1<<i) {
 				addTransToWordFigure(word, rect, lang);
 			}
 		}
@@ -1176,7 +1176,7 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 				int transLen = 0;
 				for (int i=0; i<BTSCoreConstants.LANGS.length; i++) {
 					String lang = BTSCoreConstants.LANGS[i];
-					if ((showTransLangMask & i) == i) {
+					if ((showTransLangMask & 1<<i) == 1<<i) {
 						String trans = word.getTranslation().getTranslationStrict(lang);
 						if (trans != null)
 						{

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/support/TypedLabel.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/support/TypedLabel.java
@@ -25,7 +25,7 @@ public class TypedLabel extends Label{
 
 	public String getTranslationLang() {
 		if (Integer.highestOneBit(type) == TRANSLATION) {
-			assert BTSCoreConstants.LANGS.length < 9;
+			assert BTSCoreConstants.LANGS.length < TRANSLATION + 1;
 			int langId = type ^ TRANSLATION;
 			if (langId > -1) {
 				return BTSCoreConstants.LANGS[langId];


### PR DESCRIPTION
Sign Text Editor and Preferences Page will now show previously added languages AR and IT. Translation language support has also changed in a way that will make it much easier to extend or change list of supported languages in the future. Changes made in `BTSCoreConstants.LANGS` array will automatically be reflected in STE and Preferences.