### PR TITLE
Bugfix in translation editor, translation part.

### DIFF
--- a/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/widgets/TranslationEditorComposite.java
+++ b/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/widgets/TranslationEditorComposite.java
@@ -164,68 +164,24 @@ public class TranslationEditorComposite extends Composite {
 		if (translations == null)
 		{
 			text.setText("");
-			return;
-		}
-		
-		List<String> ls = translations.getLanguages();
-		List<String> additionalInputs = new Vector<String>(ls.size());
-		for (Object o : ls) {
-			if (o instanceof String) {
-				boolean found = false;
-				for (String s : BTSCoreConstants.LANGS) {
-					if (s.equals(o)) {
-						found = true;
-						break;
-					}
-				}
-				if (!found) {
-					additionalInputs.add((String) o);
-				}
-			}
-		}
-		if (!additionalInputs.isEmpty()) {
-			for (String s : BTSCoreConstants.LANGS) {
-				if (!additionalInputs.contains(s)) {
-					additionalInputs.add(s);
-				}
-			}
-			combo.setItems(additionalInputs.toArray(new String[additionalInputs
-					.size()]));
-		}
-
-		if (lang != null) {
-			combo.select(combo.indexOf(lang));
-
-			loadTranslation(lang);
-			return;
-		}
-		if (translations.getBTSTranslation(BTSCoreConstants.LANG_EN) != null) {
-			combo.select(combo.indexOf(BTSCoreConstants.LANG_EN));
-			loadTranslation(BTSCoreConstants.LANG_EN);
-		} else if (translations.getBTSTranslation(BTSCoreConstants.LANG_DE) != null) {
-			combo.select(combo.indexOf(BTSCoreConstants.LANG_DE));
-
-			loadTranslation(BTSCoreConstants.LANG_DE);
-		} else if (translations.getBTSTranslation(BTSCoreConstants.LANG_FR) != null) {
-			combo.select(combo.indexOf(BTSCoreConstants.LANG_FR));
-
-			loadTranslation(BTSCoreConstants.LANG_FR);
-		} else if (translations.getBTSTranslation(BTSCoreConstants.LANG_ES) != null) {
-			combo.select(combo.indexOf(BTSCoreConstants.LANG_ES));
-
-			loadTranslation(BTSCoreConstants.LANG_ES);
-		} else if (translations.getBTSTranslation(BTSCoreConstants.LANG_RU) != null) {
-			combo.select(combo.indexOf(BTSCoreConstants.LANG_RU));
-
-			loadTranslation(BTSCoreConstants.LANG_RU);
-		} else {
 			combo.select(0);
-
-			loadTranslation(combo.getItem(0));
-		}
-		if (translations == null) {
 			return;
 		}
+		text.setText("");
+		combo.setText("");
+		
+		// load built-in languages
+		for (int i = 0; i < BTSCoreConstants.LANGS.length; i++) {
+			String l = BTSCoreConstants.LANGS[i];
+			String ltrans = translations.getTranslationStrict(l);
+			if (ltrans != null) {
+				combo.select(combo.indexOf(l));
+				loadTranslation(l);
+				return;
+			}
+		}
+		combo.select(0);
+		loadTranslation(combo.getItems()[0]);
 
 	}
 
@@ -241,6 +197,7 @@ public class TranslationEditorComposite extends Composite {
 		this.setBackground(BTSUIConstants.VIEW_BACKGROUND_DESELECTED_COLOR);
 		text = new Text(this, customStyle);
 		text.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
+		text.setText("");
 		
 		Label l = new Label(this, SWT.NONE);
 		l.setToolTipText("Set Language of Translation");
@@ -267,6 +224,9 @@ public class TranslationEditorComposite extends Composite {
 			}
 		});
 
+		if (translations != null) {
+			load(translations, domain, required);
+		}
 	}
 
 	/**

--- a/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/widgets/TranslationEditorComposite.java
+++ b/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/widgets/TranslationEditorComposite.java
@@ -97,8 +97,8 @@ public class TranslationEditorComposite extends Composite {
 	/** The binding context. */
 	private DataBindingContext bindingContext;
 
-	/** The lang. */
-	private String lang;
+	/** Whether to propagate changes via EMF databinding */
+	private boolean dataBind;
 
 	private List<SelectionListener> languageSelectionListeners = new ArrayList<SelectionListener>(2);
 
@@ -114,16 +114,10 @@ public class TranslationEditorComposite extends Composite {
 	 * @param required the required
 	 */
 	public TranslationEditorComposite(Composite parent, int style,
-			BTSTranslations translations, EditingDomain domain, boolean required) {
-		super(parent, SWT.NONE);
+			BTSTranslations translations, EditingDomain domain, boolean required, boolean dataBind) {
+		this(parent, style, required, dataBind);
 		this.translations = translations;
 		this.domain = domain;
-		this.required = required;
-		this.customStyle = style;
-		postConstruct();
-		if (translations != null) {
-			load(translations, domain, required);
-		}
 	}
 
 	/**
@@ -134,14 +128,22 @@ public class TranslationEditorComposite extends Composite {
 	 * @param required the required
 	 */
 	public TranslationEditorComposite(Composite parent, int style,
-			boolean required) {
+			boolean required, boolean dataBind) {
 		super(parent, SWT.NONE);
+		this.dataBind = dataBind;
 		this.required = required;
 		this.customStyle = style;
-		postConstruct();
-		if (translations != null) {
-			load(translations, domain, required);
-		}
+		createControls();
+	}
+
+	/**
+	 * Instantiates a new {@link TranslationEditorComposite} and activates databinding.
+	 * @param parent
+	 * @param style
+	 * @param required
+	 */
+	public TranslationEditorComposite(Composite parent, int style, boolean required) {
+		this(parent, style, required, true);
 	}
 	
 	/**
@@ -230,7 +232,7 @@ public class TranslationEditorComposite extends Composite {
 	/**
 	 * Post construct.
 	 */
-	private void postConstruct() {
+	private void createControls() {
 		setLayout(new GridLayout(3, false));
 		setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true, 1, 1));
 		((GridLayout) this.getLayout()).marginWidth = 0;
@@ -274,7 +276,6 @@ public class TranslationEditorComposite extends Composite {
 	 */
 	private void loadTranslation(String lang) {
 		if(translations == null) return;
-		this.lang = lang;
 		BTSTranslation trans = translations.getBTSTranslation(lang);
 		if (trans == null) {
 			trans = BtsmodelFactory.eINSTANCE.createBTSTranslation();
@@ -283,6 +284,14 @@ public class TranslationEditorComposite extends Composite {
 			// Command command = AddCommand.create(domain, translations,
 			// BtsmodelPackage.BTS_TRANSLATIONS__TRANSLATIONS, trans);
 			// domain.getCommandStack().execute(command);
+		}
+		if (trans.getValue() == null) {
+			trans.setValue("");
+		}
+		if (dataBind) {
+			databindTranslation(trans);
+		} else {
+			text.setText(trans.getValue());
 		}
 	}
 

--- a/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/widgets/TranslationEditorComposite.java
+++ b/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/widgets/TranslationEditorComposite.java
@@ -31,7 +31,6 @@ package org.bbaw.bts.ui.commons.widgets;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
 import org.bbaw.bts.btsmodel.BTSTranslation;
 import org.bbaw.bts.btsmodel.BTSTranslations;
@@ -45,7 +44,6 @@ import org.bbaw.bts.ui.commons.validator.StringNotEmptyValidator;
 import org.bbaw.bts.ui.resources.BTSResourceProvider;
 import org.eclipse.core.databinding.Binding;
 import org.eclipse.core.databinding.DataBindingContext;
-import org.eclipse.core.runtime.Assert;
 import org.eclipse.emf.databinding.EMFUpdateValueStrategy;
 import org.eclipse.emf.databinding.edit.EMFEditProperties;
 import org.eclipse.emf.edit.command.SetCommand;
@@ -61,9 +59,7 @@ import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 
 /**
@@ -333,8 +329,8 @@ public class TranslationEditorComposite extends Composite {
 	public void setEnabled(boolean enabled) {
 		if (!combo.isDisposed())
 		{
-		combo.setEnabled(enabled);
-		text.setEnabled(enabled);
+			combo.setEnabled(enabled);
+			text.setEnabled(enabled);
 		}
 		super.setEnabled(enabled);
 	}

--- a/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/widgets/TranslationEditorComposite.java
+++ b/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/widgets/TranslationEditorComposite.java
@@ -241,9 +241,6 @@ public class TranslationEditorComposite extends Composite {
 			// BtsmodelPackage.BTS_TRANSLATIONS__TRANSLATIONS, trans);
 			// domain.getCommandStack().execute(command);
 		}
-		if (trans.getValue() == null) {
-			trans.setValue("");
-		}
 		if (dataBind) {
 			databindTranslation(trans);
 		} else {

--- a/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/widgets/TranslationEditorComposite.java
+++ b/org.bbaw.bts.ui.commons/src/org/bbaw/bts/ui/commons/widgets/TranslationEditorComposite.java
@@ -302,7 +302,7 @@ public class TranslationEditorComposite extends Composite {
 			return;
 		}
 		BTSTranslation trans = translations.getBTSTranslation(combo.getItem(combo.getSelectionIndex()));
-		if ((trans.getValue() == null && !"".equals(text.getText()))
+		if ((trans.getValue() == null && !"".equals(text.getText().trim()))
 				|| !text.getText().equals(trans.getValue()))
 		{
 			org.eclipse.emf.common.command.Command command = SetCommand

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyLemmaEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyLemmaEditorPart.java
@@ -354,7 +354,7 @@ public class EgyLemmaEditorPart extends AbstractTextEditorLogic implements IBTSE
 
 		lemmaTranslate_Editor = new TranslationEditorComposite(
 				grpTranslation, SWT.WRAP | SWT.MULTI | SWT.V_SCROLL
-						| SWT.BORDER, null, null, false);
+						| SWT.BORDER, null, null, false, false);
 		lemmaTranslate_Editor.setLayoutData(new GridData(SWT.FILL, SWT.FILL,
 				true, true));
 		lemmaTranslate_Editor.layout();

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyLemmaEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyLemmaEditorPart.java
@@ -328,7 +328,6 @@ public class EgyLemmaEditorPart extends AbstractTextEditorLogic implements IBTSE
 		child.set(IBTSEditor.class, EgyLemmaEditorPart.this);
 		signTextEditor = ContextInjectionFactory.make(
 				SignTextComposite.class, child);
-		signTextEditor.setEventBroker(eventBroker);
 		signTextEditor.addFocusListener(new FocusListener() {
 			
 			@Override

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyLemmatizerPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyLemmatizerPart.java
@@ -631,7 +631,7 @@ public class EgyLemmatizerPart implements SearchViewer {
 
 		wordTranslate_Editor = new TranslationEditorComposite(transSashForm,
 				SWT.WRAP | SWT.MULTI | SWT.V_SCROLL | SWT.BORDER, null, null,
-				false);
+				false, false);
 		wordTranslate_Editor.setLayoutData(new GridData(SWT.FILL, SWT.FILL,
 				true, true));
 		wordTranslate_Editor.layout();

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyLemmatizerPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyLemmatizerPart.java
@@ -778,8 +778,8 @@ public class EgyLemmatizerPart implements SearchViewer {
 				translationViewer.setInput(subtranslations);
 				if (currentWord.getTranslation() != null) {
 					// try to autoselect current word's translation from translations list
-					String wordTrans = currentWord.getTranslation().getTranslation(lang);
-					if (wordTrans != null) {
+					String wordTrans = currentWord.getTranslation().getTranslationStrict(lang);
+					if (wordTrans != null && !wordTrans.trim().isEmpty()) {
 						translationEditorText = wordTrans;
 						for (int i=0; i<subtranslations.length; i++) {
 							if (subtranslations[i].trim().equals(wordTrans)) {

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -2264,13 +2264,6 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 		final AnnotationModelEvent ev = new AnnotationModelEvent(annotationModel);
 		if (sentence != null && !sentence.equals(selectedSentence)) {
 			selectedSentence = sentence;
-			if (selectedSentence.getTranslation() == null) {
-				Command command = AddCommand.create(editingDomain, selectedSentence,
-						BtsCorpusModelPackage.BTS_SENCTENCE__TRANSLATION,
-						BtsmodelFactory.eINSTANCE
-						.createBTSTranslations());
-				editingDomain.getCommandStack().execute(command);
-			}
 			sentenceTranslate_Editor.setEnabled(userMayEdit);
 			sentenceTranslate_Editor.load(selectedSentence.getTranslation(),
 					editingDomain, false);

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -864,7 +864,7 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 		sentenceTranslateComp.setText("Sentence Translation");
 		sentenceTranslate_Editor = new TranslationEditorComposite(
 				sentenceTranslateComp, SWT.WRAP | SWT.MULTI | SWT.V_SCROLL
-						| SWT.BORDER, null, null, false);
+						| SWT.BORDER, null, null, false, true);
 		sentenceTranslate_Editor.setLayoutData(new GridData(SWT.FILL, SWT.FILL,
 				true, true));
 		sentenceTranslateComp.layout();

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -2263,6 +2263,13 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 		final AnnotationModelEvent ev = new AnnotationModelEvent(annotationModel);
 		if (sentence != null && !sentence.equals(selectedSentence)) {
 			selectedSentence = sentence;
+			if (selectedSentence.getTranslation() == null) {
+				Command command = AddCommand.create(editingDomain, selectedSentence,
+						BtsCorpusModelPackage.BTS_SENCTENCE__TRANSLATION,
+						BtsmodelFactory.eINSTANCE
+						.createBTSTranslations());
+				editingDomain.getCommandStack().execute(command);
+			}
 			sentenceTranslate_Editor.setEnabled(userMayEdit);
 			sentenceTranslate_Editor.load(selectedSentence.getTranslation(),
 					editingDomain, false);

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -794,7 +794,6 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 					child.set(IBTSEditor.class, EgyTextEditorPart.this);
 					signTextEditor = ContextInjectionFactory.make(
 							SignTextComposite.class, child);
-					signTextEditor.setEventBroker(eventBroker);
 					plainTextComp.layout();
 					plainTextComp.pack();
 				}

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -2767,9 +2767,11 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 	@Optional
 	void eventReceivedTextRequested(
 			@UIEventTopic(BTSUIConstants.EVENT_EGY_TEXT_EDITOR_INPUT_REQUESTED+"translation_part") final BTSText current) {
-		if (current == null || !current.equals(text)) 
-			if (text != null)
-				selectionService.setSelection(text);
+		if (current == null || !current.equals(text)) {
+			if (text != null) {
+				eventBroker.post(BTSUIConstants.EVENT_EGY_TEXT_EDITOR_INPUT_REQUESTED+"response", text);
+			}
+		}
 	}
 
 	@Inject

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextTranslationPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextTranslationPart.java
@@ -47,6 +47,7 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.ui.di.Focus;
+import org.eclipse.e4.ui.di.UIEventTopic;
 import org.eclipse.e4.ui.di.UISynchronize;
 import org.eclipse.e4.ui.model.application.ui.basic.MPart;
 import org.eclipse.e4.ui.services.IServiceConstants;
@@ -200,9 +201,9 @@ public class EgyTextTranslationPart {
 		if (selectionCached)
 		{
 			loadInput(text);
-		} else
+		} else {
 			eventBroker.post(BTSUIConstants.EVENT_EGY_TEXT_EDITOR_INPUT_REQUESTED+"translation_part", text);
-			
+		}
 	}
 	
 	/**
@@ -516,6 +517,19 @@ public class EgyTextTranslationPart {
 	}
 
 	/**
+	 * Receives {@link EgyTextEditorPart}'s response to a {@link BTSText} request sent via {@link EventBroker}
+	 * as topic {@link BTSUIConstants#EVENT_EGY_TEXT_EDITOR_INPUT_REQUESTED} <code>+"translation_part"</code>.
+	 *
+	 * When response is received, {@link #setSelection(BTSIdentifiableItem)} gets called.
+	 * @param current
+	 */
+	@Inject
+	@Optional
+	void eventReceivedTextEditorResponse(
+			@UIEventTopic(BTSUIConstants.EVENT_EGY_TEXT_EDITOR_INPUT_REQUESTED+"response") final BTSText current) {
+		setSelection(current);
+	}
+	/**
 	 * Sets the selection.
 	 *
 	 * @param selection the new selection
@@ -583,9 +597,14 @@ public class EgyTextTranslationPart {
 	 */
 	@Focus
 	public void setFocus() {
-		if (!loaded && selectionCached) // not yet loaded but has cached selection
-		{
-			loadInput(text);
+		if (!loaded) {
+			if (selectionCached) // not yet loaded but has cached selection
+			{
+				loadInput(text);
+				textViewer.refresh();
+			} else {
+				eventBroker.post(BTSUIConstants.EVENT_EGY_TEXT_EDITOR_INPUT_REQUESTED+"translation_part", text);
+			}
 		}
 	}
 	

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
@@ -70,7 +70,6 @@ import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.e4.core.di.extensions.Preference;
 import org.eclipse.e4.ui.di.UISynchronize;
-import org.eclipse.e4.ui.services.internal.events.EventBroker;
 import org.eclipse.emf.common.notify.Adapter;
 import org.eclipse.emf.common.notify.Notification;
 import org.eclipse.emf.common.notify.Notifier;
@@ -1526,10 +1525,6 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 		// }
 		mdc = textEditorController.transformWordToMdCString(word, -1);
 		return mdc; // mdc;
-	}
-
-	public void setEventBroker(EventBroker eventBroker2) {
-		// TODO
 	}
 
 	@Override

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
@@ -1090,10 +1090,11 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 			String language) {
 		TypedLabel l = new TypedLabel();
 		l.setTranslationLang(language);
-		if (word.getTranslation() != null 
-				&& word.getTranslation().getTranslation(language) != null 
-				&& !"".equals(word.getTranslation().getTranslation(language))) {
-			l.setText(language + ": " + word.getTranslation().getTranslation(language));
+		if (word.getTranslation() != null) {
+			String trans = word.getTranslation().getTranslationStrict(language);
+			if (trans != null && !"".equals(trans)) {
+				l.setText(language + ": " + trans);
+			}
 		}
 		rect.add(l);
 	}
@@ -1735,7 +1736,7 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 						case TypedLabel.TRANSLATION :
 							if (word.getTranslation() != null) {
 								String lang = l.getTranslationLang();
-								String trans = word.getTranslation().getTranslation(lang);
+								String trans = word.getTranslation().getTranslationStrict(lang);
 								l.setText(lang + ":" + (trans != null ? trans : ""));
 							}
 							break;

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/dialogs/BTSConfigurationDialog.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/dialogs/BTSConfigurationDialog.java
@@ -797,7 +797,7 @@ public class BTSConfigurationDialog extends TitleAreaDialog {
 		lblLabel_1.setText("Label");
 
 		labelText_CIEdit = new TranslationEditorComposite(configItemEditComp,
-				SWT.BORDER, null, null, true);
+				SWT.BORDER, true);
 		labelText_CIEdit.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true,
 				false, 2, 1));
 
@@ -807,7 +807,7 @@ public class BTSConfigurationDialog extends TitleAreaDialog {
 		lblDescription.setText("Description");
 
 		descText_CIEdit = new TranslationEditorComposite(configItemEditComp,
-				SWT.BORDER, null, null, false);
+				SWT.BORDER, false);
 		descText_CIEdit.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true,
 				false, 2, 1));
 
@@ -1669,7 +1669,7 @@ public class BTSConfigurationDialog extends TitleAreaDialog {
 		lblLabel_1.setText("Label");
 
 		labelText_CIEdit = new TranslationEditorComposite(configItemEditComp,
-				SWT.BORDER, null, null, true);
+				SWT.BORDER, true);
 		labelText_CIEdit.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true,
 				false, 2, 1));
 
@@ -1679,7 +1679,7 @@ public class BTSConfigurationDialog extends TitleAreaDialog {
 		lblDescription.setText("Description");
 
 		descText_CIEdit = new TranslationEditorComposite(configItemEditComp,
-				SWT.BORDER, null, null, false);
+				SWT.BORDER, false);
 		descText_CIEdit.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true,
 				false, 2, 1));
 


### PR DESCRIPTION
Because of recent changes (c13bba944a8f6e620e406aac1b370db393a66558) in lemmatizer part, translation editor widget stopped working for text editor. This has now been fixed.

Amongst other, mostly non-functional changes, the mode of communication between text editor and translation part has been changed from selection service to event broker. This allows for the translation part to receive a requested text object whenever required.