### PR TITLE
Prevent unauthorized users from making changes in thesaurus object passport data.

### DIFF
--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/dialogs/PassportEditorDialog.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/dialogs/PassportEditorDialog.java
@@ -16,6 +16,7 @@ import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Point;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Shell;
@@ -32,6 +33,8 @@ public class PassportEditorDialog extends TitleAreaDialog {
 	@Inject
 	private CorpusNavigatorController corpusNavigator;
 	private PassportEditorPart editor;
+
+	private Button okButton;
 
 	private boolean editable;
 	/**
@@ -82,8 +85,9 @@ public class PassportEditorDialog extends TitleAreaDialog {
 	 */
 	@Override
 	protected void createButtonsForButtonBar(Composite parent) {
-		createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL,
+		okButton = createButton(parent, IDialogConstants.OK_ID, IDialogConstants.OK_LABEL,
 				true);
+		okButton.setEnabled(editable);
 		createButton(parent, IDialogConstants.CANCEL_ID,
 				IDialogConstants.CANCEL_LABEL, false);
 	}
@@ -111,5 +115,6 @@ public class PassportEditorDialog extends TitleAreaDialog {
 	public void setEditable(boolean editable)
 	{
 		this.editable = editable;
+		this.okButton.setEnabled(editable);
 	}
 }

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/PassportEditorPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/PassportEditorPart.java
@@ -179,6 +179,9 @@ public class PassportEditorPart {
 	private PassportConfigurationController passportConfigurationController;
 
 	@Inject
+	private PermissionsAndExpressionsEvaluationController permissionsController;
+
+	@Inject
 	private ECommandService commandService;
 
 	@Inject
@@ -946,6 +949,9 @@ public class PassportEditorPart {
 	}
 
 	private void loadInput(BTSCorpusObject object) {
+
+		userMayEdit = permissionsController.userMayEditObject(permissionsController.getAuthenticatedUser(), object);
+		context.set(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT, userMayEdit);
 
 		purgeAll();
 		if (object.getPassport() == null) {


### PR DESCRIPTION
Passport editor opened from another passport editor did allow unauthorized modification on object metadata.