### PR TITLE
Don't show corpus texts in annotations part.

### DIFF
--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
@@ -309,7 +309,7 @@ public class AnnotationsPart implements EventHandler {
 
 	@Inject
 	@Optional
-	void eventReceivedRelatingObjectsLoadedEvents(
+	void eventReceivedRelatingObjectsLoaded(
 			@EventTopic("event_text_relating_objects/*") final BTSRelatingObjectsLoadingEvent event) {
 		parentObject = event.getObject();
 		queryId = "relations.objectId-" + parentObject.get_id();
@@ -542,7 +542,7 @@ public class AnnotationsPart implements EventHandler {
 		}
 		case "event_text_relating_objects/selected" :
 		{
-			eventReceivedRelatingObjectsSelectedEvents(event.getProperty("org.eclipse.e4.data"));
+			eventReceivedRelatingObjectsSelected(event.getProperty("org.eclipse.e4.data"));
 			break;
 		}
 		}
@@ -591,14 +591,14 @@ public class AnnotationsPart implements EventHandler {
 				if (filteredRelatingObjects != null && !filteredRelatingObjects.isEmpty())
 				{
 					relatingObjectsQueryIDMap.put(queryId, filteredRelatingObjects);
-					eventReceivedRelatingObjectsSelectedEvents(filteredRelatingObjects);
+					eventReceivedRelatingObjectsSelected(filteredRelatingObjects);
 				}
 			}
 		}
 		else if (selection instanceof BTSTextSelectionEvent)
 		{
 			this.textSelectionEvent = (BTSTextSelectionEvent) selection;
-			eventReceivedRelatingObjectsSelectedEvents(textSelectionEvent.getRelatingObjects());
+			eventReceivedRelatingObjectsSelected(textSelectionEvent.getRelatingObjects());
 		}
 		}
 		else
@@ -674,13 +674,13 @@ public class AnnotationsPart implements EventHandler {
 			filters.put(key, !filters.get(key));
 		}
 		if (this.relatingObjectsEvent != null) {
-			eventReceivedRelatingObjectsLoadedEvent(relatingObjectsEvent);
+			eventReceivedRelatingObjectsLoaded(relatingObjectsEvent);
 		}
 		eventBroker.post("event_anno_filters/anno_part", 
 				new BTSRelatingObjectsFilterEvent(filters));
 	}
 
-	private void eventReceivedRelatingObjectsSelectedEvents(Object objects) {
+	private void eventReceivedRelatingObjectsSelected(Object objects) {
 		if (objects == null)
 		{
 			setSelectedInternal(null, false);

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
@@ -670,11 +670,14 @@ public class AnnotationsPart implements EventHandler {
 		// toggle
 		//String key = "org.bbaw.bts.ui.corpus.part.annotations.viewmenu.show." + filter;
 		String key = filter;
-		filters.put(key, !filters.get(key));
-		if (this.relatingObjectsEvent != null)
-			eventReceivedRelatingObjectsLoadedEvents(relatingObjectsEvent);
-		BTSRelatingObjectsFilterEvent e = new BTSRelatingObjectsFilterEvent(filters);
-		eventBroker.post("event_anno_filters/anno_part", e);
+		if (filters.containsKey(key)) {
+			filters.put(key, !filters.get(key));
+		}
+		if (this.relatingObjectsEvent != null) {
+			eventReceivedRelatingObjectsLoadedEvent(relatingObjectsEvent);
+		}
+		eventBroker.post("event_anno_filters/anno_part", 
+				new BTSRelatingObjectsFilterEvent(filters));
 	}
 
 	private void eventReceivedRelatingObjectsSelectedEvents(Object objects) {

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
@@ -572,7 +572,7 @@ public class AnnotationsPart implements EventHandler {
 			queryId = "relations.objectId-" + ((BTSCorpusObject)selection).get_id();
 			parentObject = (BTSCorpusObject)selection;
 			// if BTSText wait to receive relationObjectLoadedEvent through eventBroker!
-			if (!(selection instanceof BTSText))
+			if (!(selection instanceof BTSText) && false)
 			{
 				try {
 					relatingObjects = annotationPartController.findRelatingObjects((BTSObject) selection, null);

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
@@ -572,7 +572,7 @@ public class AnnotationsPart implements EventHandler {
 			queryId = "relations.objectId-" + ((BTSCorpusObject)selection).get_id();
 			parentObject = (BTSCorpusObject)selection;
 			// if BTSText wait to receive relationObjectLoadedEvent through eventBroker!
-			if (!(selection instanceof BTSText) && false)
+			if (!(selection instanceof BTSText))
 			{
 				try {
 					relatingObjects = annotationPartController.findRelatingObjects((BTSObject) selection, null);

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
@@ -639,7 +639,7 @@ public class AnnotationsPart implements EventHandler {
 				}
 		} else if (o instanceof BTSComment)
 			key += "comment";
-		return filters.containsKey(key) ? filters.get(key) : true;
+		return filters.containsKey(key) ? filters.get(key) : false;
 	}
 
 


### PR DESCRIPTION
Thanks to past changes to the way the annotations part processes related objects, a selection of anything other than a text object in corpus navigator used to make annotations part load and display text objects. This behaviour was not desired, so it was simply disabled. This solution is up for debate, as the question arises why this behaviour was implemented in the first place.