### PR TITLE
Restrict choice of main corpus in preferences.

### DIFF
--- a/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
+++ b/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
@@ -1,5 +1,6 @@
 package org.bbaw.bts.core.controller.impl.generalController;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -110,6 +111,8 @@ public class PermissionsAndExpressionsEvaluationControllerImpl implements
 	private BTSProjectService projecService;
 
 	private List<BTSProject> allProjects;
+
+	private Map<String, BTSProjectDBCollection> dbCollectionCache;
 
 
 	@Inject
@@ -667,24 +670,28 @@ public class PermissionsAndExpressionsEvaluationControllerImpl implements
 		
 	}
 
+	private BTSProjectDBCollection getDBCollection(String dbCollectionName) {
+		if (dbCollectionCache == null) {
+			dbCollectionCache= new HashMap<String, BTSProjectDBCollection>();
+			for (BTSProject project : getAllProjects())
+			{
+				for (BTSProjectDBCollection c : project.getDbCollections()) {
+					if (c.getCollectionName() != null) {
+						dbCollectionCache.put(c.getCollectionName(), c);
+					}
+				}
+			}
+		}
+		return dbCollectionCache.get(dbCollectionName);
+	}
+
 	private boolean userRoleMayEdit(BTSUser user, BTSDBBaseObject object) {
 		String localUserContextRole = BTSCoreConstants.USER_ROLE_GUESTS;
 		if (user == null || object == null) {
 
 		} else {
-			for (BTSProject project : getAllProjects())
-			{
-				if (project.getPrefix() != null && project.getPrefix().equals(object.getProject()))
-				{
-					for (BTSProjectDBCollection c : project.getDbCollections()) {
-						if (c.getCollectionName() != null
-								&& c.getCollectionName().equals(object.getDBCollectionKey())) {
-							localUserContextRole = evaluationService.highestRoleOfUserInDBCollection(user, c);
-							break;
-						}
-					}
-				}
-			}
+			BTSProjectDBCollection c = getDBCollection(object.getDBCollectionKey());
+			localUserContextRole = evaluationService.highestRoleOfUserInDBCollection(user, c);
 		}
 		return (localUserContextRole != null && (localUserContextRole
 				.equals(BTSCoreConstants.USER_ROLE_ADMINS) || localUserContextRole
@@ -698,6 +705,17 @@ public class PermissionsAndExpressionsEvaluationControllerImpl implements
 		}
 		return allProjects;
 	}
+
+	@Override
+	public boolean authenticatedUserMayAddToDBCollection(
+			String dbCollectionName) {
+		BTSProjectDBCollection dbCollection = getDBCollection(dbCollectionName);
+		String localUserContextRole = evaluationService.highestRoleOfUserInDBCollection(authenticatedUser, dbCollection);
+		return (localUserContextRole != null && (localUserContextRole
+				.equals(BTSCoreConstants.USER_ROLE_ADMINS) || localUserContextRole
+				.equals(BTSCoreConstants.USER_ROLE_EDITORS)));
+	}
+
 
 	@Override
 	public boolean authenticatedUserMayAddToDBCollection(

--- a/org.bbaw.bts.core.controller/src/org/bbaw/bts/core/controller/generalController/PermissionsAndExpressionsEvaluationController.java
+++ b/org.bbaw.bts.core.controller/src/org/bbaw/bts/core/controller/generalController/PermissionsAndExpressionsEvaluationController.java
@@ -87,8 +87,11 @@ public interface PermissionsAndExpressionsEvaluationController {
 
 	boolean authenticatedUserMayAddToDBCollection(BTSProjectDBCollection dbCollection);
 
+	boolean authenticatedUserMayAddToDBCollection(String dbCollectionName);
+
 	boolean authenticatedUserMayDeleteProject(BTSProject project);
 	
 	boolean authenticatedUserMayDeleteUserOrUserGroup(BTSObject object);
+
 
 }

--- a/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/CorpusNavigatorControllerImpl.java
+++ b/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/CorpusNavigatorControllerImpl.java
@@ -11,7 +11,7 @@ import org.bbaw.bts.btsviewmodel.TreeNodeWrapper;
 import org.bbaw.bts.commons.BTSConstants;
 import org.bbaw.bts.core.commons.comparator.BTSObjectByNameComparator;
 import org.bbaw.bts.core.commons.filter.BTSFilter;
-import org.bbaw.bts.core.corpus.controller.impl.util.BTSEgyObjectByNameComparator;
+import org.bbaw.bts.core.controller.generalController.PermissionsAndExpressionsEvaluationController;
 import org.bbaw.bts.core.corpus.controller.partController.CorpusNavigatorController;
 import org.bbaw.bts.core.dao.util.BTSQueryRequest;
 import org.bbaw.bts.core.services.Backend2ClientUpdateService;
@@ -68,6 +68,9 @@ implements CorpusNavigatorController
 
 	@Inject
 	private BTSLemmaEntryService wlistService;
+
+	@Inject
+	private PermissionsAndExpressionsEvaluationController permissionController;
 	
 	@Inject
 	private Logger logger;
@@ -375,10 +378,14 @@ implements CorpusNavigatorController
 
 	@Override
 	public List<BTSTextCorpus> listTextCorpora(IProgressMonitor monitor) {
-		List<BTSTextCorpus> corpora = textCorpusService.list(BTSConstants.OBJECT_STATE_ACTIVE, monitor);
-		for (BTSTextCorpus c : corpora)
+		List<BTSTextCorpus> corpora = new Vector<BTSTextCorpus>();
+		for (BTSTextCorpus c : textCorpusService.list(BTSConstants.OBJECT_STATE_ACTIVE, monitor))
 		{
-			checkAndFullyLoad(c, true);
+			String dbCollectionName = c.getDBCollectionKey() + "_" + c.getCorpusPrefix();
+			if (permissionController.authenticatedUserMayAddToDBCollection(dbCollectionName)) {
+				checkAndFullyLoad(c, true);
+				corpora.add(c);
+			}
 		}
 		sortBTSTextCorpus(corpora);
 		return corpora;

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/preferences/CorpusSettingsPage.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/preferences/CorpusSettingsPage.java
@@ -45,7 +45,7 @@ import com.richclientgui.toolbox.duallists.DualListComposite;
 
 public class CorpusSettingsPage extends FieldEditorPreferencePage {
 
-	private ComboViewer comboViewer;
+	private ComboViewer mainCorpusComboViewer;
 	private BTSTextCorpus selectedTextCorpus;
 	private String main_corpus_key;
 	private DualListComposite<BTSCorpusObject> duallistcomposite;
@@ -84,7 +84,7 @@ public class CorpusSettingsPage extends FieldEditorPreferencePage {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				activate = !activate;
-				comboViewer.getCombo().setEnabled(activate);
+				mainCorpusComboViewer.getCombo().setEnabled(activate);
 				
 			}
 			
@@ -100,14 +100,14 @@ public class CorpusSettingsPage extends FieldEditorPreferencePage {
 		lblSelectYourMain.setLayoutData(new GridData(SWT.LEFT, SWT.TOP, false, false, 1, 1));
 		lblSelectYourMain.setText("Select your main working corpus");
 
-		comboViewer = new ComboViewer(container, SWT.READ_ONLY);
-		comboViewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false, 1, 1));
+		mainCorpusComboViewer = new ComboViewer(container, SWT.READ_ONLY);
+		mainCorpusComboViewer.getControl().setLayoutData(new GridData(SWT.FILL, SWT.TOP, true, false, 1, 1));
 
 		ComposedAdapterFactory factory = new ComposedAdapterFactory(ComposedAdapterFactory.Descriptor.Registry.INSTANCE);
 		AdapterFactoryLabelProvider labelProvider = new AdapterFactoryLabelProvider(factory);
-		comboViewer.setContentProvider(new ListContentProvider());
-		comboViewer.setLabelProvider(labelProvider);
-		comboViewer.addSelectionChangedListener(new ISelectionChangedListener()
+		mainCorpusComboViewer.setContentProvider(new ListContentProvider());
+		mainCorpusComboViewer.setLabelProvider(labelProvider);
+		mainCorpusComboViewer.addSelectionChangedListener(new ISelectionChangedListener()
 		{
 
 			@Override
@@ -157,7 +157,7 @@ public class CorpusSettingsPage extends FieldEditorPreferencePage {
 		
 		activate = prefs.getBoolean(BTSPluginIDs.PREF_CORPUS_ACTIVATE_MAIN_CORPUS_SELECTION, false);
 		initialActivate = new Boolean(activate);
-		comboViewer.getCombo().setEnabled(activate);
+		mainCorpusComboViewer.getCombo().setEnabled(activate);
 		activateButton.setSelection(activate);
 
 	}
@@ -167,7 +167,7 @@ public class CorpusSettingsPage extends FieldEditorPreferencePage {
 	{
 
 		corpora = corpusController.listTextCorpora(null);
-		comboViewer.setInput(corpora);
+		mainCorpusComboViewer.setInput(corpora);
 		List<BTSCorpusObject> availableCorpora = new Vector<BTSCorpusObject>(1);
 
 		List<BTSCorpusObject> chosenCorpora = new Vector<BTSCorpusObject>(1);
@@ -187,7 +187,7 @@ public class CorpusSettingsPage extends FieldEditorPreferencePage {
 				if (main_corpus_key != null && main_corpus_key.equals(corpus.getDBCollectionKey() + "_" + corpus.getCorpusPrefix()))
 				{
 					selectedTextCorpus = corpus;
-					comboViewer.setSelection(new StructuredSelection(corpus));
+					mainCorpusComboViewer.setSelection(new StructuredSelection(corpus));
 				}
 				for (String p : pros)
 				{


### PR DESCRIPTION
User can only select corpora they can actually create objects in as their main corpus. In preferences. Under corpus settings.