### PR TITLE
Display text editor annotation ranges in correct color.

### DIFF
--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -2819,7 +2819,9 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 							painter.addAnnotationType(typeId+suffix,
 									strategyId+suffix);
 							painter.setAnnotationTypeColor(typeId+suffix,
-									BTSUIConstants.COLOR_ANNOTATTION);
+									typeId.endsWith(BTSAnnotationAnnotation.TYPE_RUBRUM)
+									? BTSUIConstants.COLOR_RUBRUM
+									: BTSUIConstants.COLOR_ANNOTATTION);
 							oruler.addAnnotationType(typeId+suffix);
 						} else {
 							painter.removeAnnotationType(typeId+suffix);

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -2818,10 +2818,10 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 						if (strategyId != null) {
 							painter.addAnnotationType(typeId+suffix,
 									strategyId+suffix);
-							painter.setAnnotationTypeColor(typeId+suffix,
-									typeId.endsWith(BTSAnnotationAnnotation.TYPE_RUBRUM)
-									? BTSUIConstants.COLOR_RUBRUM
-									: BTSUIConstants.COLOR_ANNOTATTION);
+							if (typeId.startsWith(BTSAnnotationAnnotation.TYPE)) {
+								painter.setAnnotationTypeColor(typeId+suffix,
+										BTSUIConstants.COLOR_ANNOTATTION);
+							}
 							oruler.addAnnotationType(typeId+suffix);
 						} else {
 							painter.removeAnnotationType(typeId+suffix);


### PR DESCRIPTION
Quick fix for release. Due to recent changes [ad8f4ae4dbb8a65a0c6c80612309d9b5eed77a42], all kinds of related objects were displayed in the same color as annotations.