### PR TITLE
Access rights on text corpus objects.

### DIFF
--- a/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
+++ b/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
@@ -718,9 +718,10 @@ public class PermissionsAndExpressionsEvaluationControllerImpl implements
 	public boolean authenticatedUserMayAddToDBCollection(
 			BTSProjectDBCollection dbCollection) {
 		String localUserContextRole = evaluationService.highestRoleOfUserInDBCollection(authenticatedUser, dbCollection);
-		return (localUserContextRole != null && (localUserContextRole
-				.equals(BTSCoreConstants.USER_ROLE_ADMINS) || localUserContextRole
-				.equals(BTSCoreConstants.USER_ROLE_EDITORS)));
+		return (localUserContextRole != null
+				&& (localUserContextRole.equals(BTSCoreConstants.USER_ROLE_ADMINS)
+					|| localUserContextRole.equals(BTSCoreConstants.USER_ROLE_EDITORS)
+					|| localUserContextRole.equals(BTSCoreConstants.USER_ROLE_RESEARCHERS)));
 	}
 
 	@Override
@@ -735,8 +736,8 @@ public class PermissionsAndExpressionsEvaluationControllerImpl implements
 		String userRole = evaluationService.highestRoleOfUserInDBCollection(authenticatedUser, dbCollection);
 		return (userRole != null && (userRole.equals(BTSCoreConstants.USER_ROLE_ADMINS)
 				|| userRole.equals(BTSCoreConstants.USER_ROLE_EDITORS)
-				|| userRole.equals(BTSCoreConstants.USER_ROLE_TRANSCRIBERS)
-				|| userRole.equals(BTSCoreConstants.USER_ROLE_RESEARCHERS)));
+				|| userRole.equals(BTSCoreConstants.USER_ROLE_RESEARCHERS)
+				|| userRole.equals(BTSCoreConstants.USER_ROLE_TRANSCRIBERS)));
 	}
 
 	@Override

--- a/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
+++ b/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
@@ -724,6 +724,22 @@ public class PermissionsAndExpressionsEvaluationControllerImpl implements
 	}
 
 	@Override
+	public boolean authenticatedUserMayReadDBCollection(String dbCollectionName) {
+		BTSProjectDBCollection dbCollection = getDBCollection(dbCollectionName);
+		return authenticatedUserMayReadDBCollection(dbCollection);
+	}
+
+	@Override
+	public boolean authenticatedUserMayReadDBCollection(
+			BTSProjectDBCollection dbCollection) {
+		String userRole = evaluationService.highestRoleOfUserInDBCollection(authenticatedUser, dbCollection);
+		return (userRole != null && (userRole.equals(BTSCoreConstants.USER_ROLE_ADMINS)
+				|| userRole.equals(BTSCoreConstants.USER_ROLE_EDITORS)
+				|| userRole.equals(BTSCoreConstants.USER_ROLE_TRANSCRIBERS)
+				|| userRole.equals(BTSCoreConstants.USER_ROLE_RESEARCHERS)));
+	}
+
+	@Override
 	public boolean authenticatedUserMayDeleteProject(BTSProject project) {
 		if (!authenticatedUserIsDBAdmin(true))
 		{

--- a/org.bbaw.bts.core.controller/src/org/bbaw/bts/core/controller/generalController/PermissionsAndExpressionsEvaluationController.java
+++ b/org.bbaw.bts.core.controller/src/org/bbaw/bts/core/controller/generalController/PermissionsAndExpressionsEvaluationController.java
@@ -95,6 +95,10 @@ public interface PermissionsAndExpressionsEvaluationController {
 	 * <p>I.e. <code>BTSDBBaseObject</code>'s <i>DB Collection Key</i> attribute, followed by underscore,
 	 * followed by <code>BTSCorpusObject</code>'s <i>Corpus Prefix</i> attribute.</p>
 	 *
+	 * <p><code>DBCollectionKey</code> attributes set to <code>BTSCorpusObject</code>s satisfy
+	 * this requirement, only in case of <code>BTSTextCorpus</code> objects, there is
+	 * some assembly required.</p>
+	 *
 	 * @param dbCollectionName collection identifier, conforming to <code>"&lt;DBCollectionKey&gt;_&lt;CorpusPrefix&gt;"</code>. 
 	 * @return true, if user is allowed to create object in specified corpus.
 	 */
@@ -109,6 +113,10 @@ public interface PermissionsAndExpressionsEvaluationController {
 	 * <p><code>"&lt;DBCollectionKey&gt;_&lt;CorpusPrefix&gt;"</code></p>
 	 * <p>I.e. <code>BTSDBBaseObject</code>'s <i>DB Collection Key</i> attribute, followed by underscore,
 	 * followed by <code>BTSCorpusObject</code>'s <i>Corpus Prefix</i> attribute.</p>
+	 *
+	 * <p><code>DBCollectionKey</code> attributes set to <code>BTSCorpusObject</code>s satisfy
+	 * this requirement, only in case of <code>BTSTextCorpus</code> objects, there is
+	 * some assembly required.</p>
 	 *
 	 * @param dbCollectionName collection identifier, conforming to <code>"&lt;DBCollectionKey&gt;_&lt;CorpusPrefix&gt;"</code>. 
 	 * @return true, if user is allowed to read specified corpus

--- a/org.bbaw.bts.core.controller/src/org/bbaw/bts/core/controller/generalController/PermissionsAndExpressionsEvaluationController.java
+++ b/org.bbaw.bts.core.controller/src/org/bbaw/bts/core/controller/generalController/PermissionsAndExpressionsEvaluationController.java
@@ -87,6 +87,17 @@ public interface PermissionsAndExpressionsEvaluationController {
 
 	boolean authenticatedUserMayAddToDBCollection(BTSProjectDBCollection dbCollection);
 
+	/**
+	 * Evaluates whether the current user is permitted to create objects within the corpus
+	 * specified by identifier in parameter. In order to evaluate correctly, the identifier
+	 * needs to conform to this format:
+	 * <p><code>"&lt;DBCollectionKey&gt;_&lt;CorpusPrefix&gt;"</code></p>
+	 * <p>I.e. <code>BTSDBBaseObject</code>'s <i>DB Collection Key</i> attribute, followed by underscore,
+	 * followed by <code>BTSCorpusObject</code>'s <i>Corpus Prefix</i> attribute.</p>
+	 *
+	 * @param dbCollectionName collection identifier, conforming to <code>"&lt;DBCollectionKey&gt;_&lt;CorpusPrefix&gt;"</code>. 
+	 * @return true, if user is allowed to create object in specified corpus.
+	 */
 	boolean authenticatedUserMayAddToDBCollection(String dbCollectionName);
 
 	boolean authenticatedUserMayDeleteProject(BTSProject project);

--- a/org.bbaw.bts.core.controller/src/org/bbaw/bts/core/controller/generalController/PermissionsAndExpressionsEvaluationController.java
+++ b/org.bbaw.bts.core.controller/src/org/bbaw/bts/core/controller/generalController/PermissionsAndExpressionsEvaluationController.java
@@ -100,8 +100,23 @@ public interface PermissionsAndExpressionsEvaluationController {
 	 */
 	boolean authenticatedUserMayAddToDBCollection(String dbCollectionName);
 
+	boolean authenticatedUserMayReadDBCollection(BTSProjectDBCollection dbCollection);
+
+	/**
+	 * Evaluates whether the current user is permitted to read objects of the corpus
+	 * specified by identifier in parameter. In order to evaluate correctly, the identifier
+	 * needs to conform to this format:
+	 * <p><code>"&lt;DBCollectionKey&gt;_&lt;CorpusPrefix&gt;"</code></p>
+	 * <p>I.e. <code>BTSDBBaseObject</code>'s <i>DB Collection Key</i> attribute, followed by underscore,
+	 * followed by <code>BTSCorpusObject</code>'s <i>Corpus Prefix</i> attribute.</p>
+	 *
+	 * @param dbCollectionName collection identifier, conforming to <code>"&lt;DBCollectionKey&gt;_&lt;CorpusPrefix&gt;"</code>. 
+	 * @return true, if user is allowed to read specified corpus
+	 */
+	boolean authenticatedUserMayReadDBCollection(String dbCollectionName);
+
 	boolean authenticatedUserMayDeleteProject(BTSProject project);
-	
+
 	boolean authenticatedUserMayDeleteUserOrUserGroup(BTSObject object);
 
 

--- a/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/AbstractCorpusObjectNavigatorControllerImpl.java
+++ b/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/AbstractCorpusObjectNavigatorControllerImpl.java
@@ -26,6 +26,7 @@ import org.bbaw.bts.core.services.IDService;
 import org.bbaw.bts.core.services.corpus.CorpusObjectService;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSAnnotation;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSCorpusObject;
+import org.bbaw.bts.corpus.btsCorpusModel.BTSTextCorpus;
 import org.bbaw.bts.searchModel.BTSModelUpdateNotification;
 import org.bbaw.bts.searchModel.BTSQueryResultAbstract;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -486,8 +487,12 @@ GenericCorpusObjectNavigatorController<E, K>
 
 	@Override
 	public String getDBCollectionName(E o) {
-		return String.format("%s_%s",
-			o.getDBCollectionKey(),
-			o.getCorpusPrefix());
+		if (o instanceof BTSTextCorpus) {
+			return String.format("%s_%s",
+				o.getDBCollectionKey(),
+				o.getCorpusPrefix());
+		} else {
+			return o.getDBCollectionKey();
+		}
 	}
 }

--- a/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/AbstractCorpusObjectNavigatorControllerImpl.java
+++ b/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/AbstractCorpusObjectNavigatorControllerImpl.java
@@ -483,4 +483,11 @@ GenericCorpusObjectNavigatorController<E, K>
 		}
 		return nodes;
 	}
+
+	@Override
+	public String getDBCollectionName(E o) {
+		return String.format("%s_%s",
+			o.getDBCollectionKey(),
+			o.getCorpusPrefix());
+	}
 }

--- a/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/CorpusNavigatorControllerImpl.java
+++ b/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/CorpusNavigatorControllerImpl.java
@@ -382,9 +382,7 @@ implements CorpusNavigatorController
 		List<BTSTextCorpus> corpora = new Vector<BTSTextCorpus>();
 		for (BTSTextCorpus c : textCorpusService.list(BTSConstants.OBJECT_STATE_ACTIVE, monitor))
 		{
-			String dbCollectionName = String.format("%s_%s",
-					c.getDBCollectionKey(),
-					c.getCorpusPrefix());
+			String dbCollectionName = getDBCollectionName(c);
 			if (c.getVisibility().equals(BTSCoreConstants.VISIBILITY_PUBLIC)
 					|| permissionController.authenticatedUserMayReadDBCollection(dbCollectionName)) {
 				checkAndFullyLoad(c, true);

--- a/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/CorpusNavigatorControllerImpl.java
+++ b/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/CorpusNavigatorControllerImpl.java
@@ -9,6 +9,7 @@ import javax.inject.Inject;
 
 import org.bbaw.bts.btsviewmodel.TreeNodeWrapper;
 import org.bbaw.bts.commons.BTSConstants;
+import org.bbaw.bts.core.commons.BTSCoreConstants;
 import org.bbaw.bts.core.commons.comparator.BTSObjectByNameComparator;
 import org.bbaw.bts.core.commons.filter.BTSFilter;
 import org.bbaw.bts.core.controller.generalController.PermissionsAndExpressionsEvaluationController;
@@ -381,8 +382,11 @@ implements CorpusNavigatorController
 		List<BTSTextCorpus> corpora = new Vector<BTSTextCorpus>();
 		for (BTSTextCorpus c : textCorpusService.list(BTSConstants.OBJECT_STATE_ACTIVE, monitor))
 		{
-			String dbCollectionName = c.getDBCollectionKey() + "_" + c.getCorpusPrefix();
-			if (permissionController.authenticatedUserMayAddToDBCollection(dbCollectionName)) {
+			String dbCollectionName = String.format("%s_%s",
+					c.getDBCollectionKey(),
+					c.getCorpusPrefix());
+			if (c.getVisibility().equals(BTSCoreConstants.VISIBILITY_PUBLIC)
+					|| permissionController.authenticatedUserMayReadDBCollection(dbCollectionName)) {
 				checkAndFullyLoad(c, true);
 				corpora.add(c);
 			}

--- a/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/CorpusNavigatorControllerImpl.java
+++ b/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/CorpusNavigatorControllerImpl.java
@@ -393,6 +393,12 @@ implements CorpusNavigatorController
 		return corpora;
 	}
 
+	@Override
+	public boolean isWriteable(BTSTextCorpus corpus) {
+		return permissionController.authenticatedUserMayAddToDBCollection(
+				getDBCollectionName(corpus));
+	}
+
 	private void sortBTSTextCorpus(List<BTSTextCorpus> list) {
 		Collections.sort(list, new BTSObjectByNameComparator());
 		

--- a/org.bbaw.bts.core.corpus.controller/src/org/bbaw/bts/core/corpus/controller/partController/CorpusNavigatorController.java
+++ b/org.bbaw.bts.core.corpus.controller/src/org/bbaw/bts/core/corpus/controller/partController/CorpusNavigatorController.java
@@ -43,7 +43,9 @@ public interface CorpusNavigatorController extends GenericCorpusObjectNavigatorC
 //	BTSCorpusObject findObject(String id);
 	
 	List<BTSTextCorpus> listTextCorpora(IProgressMonitor monitor);
-	
+
+	boolean isWriteable(BTSTextCorpus corpus);
+
 	boolean makeAndSaveNewTextCorpus(BTSTextCorpus corpus, boolean synchronizeCorpus);
 
 	BTSTextCorpus findTextCorpusByPrefix(String corpusPrefix);

--- a/org.bbaw.bts.core.corpus.controller/src/org/bbaw/bts/core/corpus/controller/partController/GenericCorpusObjectNavigatorController.java
+++ b/org.bbaw.bts.core.corpus.controller/src/org/bbaw/bts/core/corpus/controller/partController/GenericCorpusObjectNavigatorController.java
@@ -57,4 +57,6 @@ public interface GenericCorpusObjectNavigatorController <E extends BTSCorpusObje
 	boolean checkAndFullyLoad(BTSCorpusObject object, boolean checkForConflicts);
 	
 	List<TreeNodeWrapper> loadNodes(List<E> obs, IProgressMonitor monitor, boolean asStructuredTree);
+
+	String getDBCollectionName(E o);
 }

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/handlers/AddNewTCObjectHandler.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/handlers/AddNewTCObjectHandler.java
@@ -23,6 +23,9 @@ public class AddNewTCObjectHandler
 	@Inject
 	private PermissionsAndExpressionsEvaluationController permissionController;
 
+	@Inject
+	private CorpusNavigatorController navigatorController;
+
 	@Execute
 	public void execute(@Named(IServiceConstants.ACTIVE_SELECTION) @Optional BTSCorpusObject selection,
 			@Named(IServiceConstants.ACTIVE_SHELL) final Shell shell, EventBroker eventBroker,
@@ -37,10 +40,8 @@ public class AddNewTCObjectHandler
 	public boolean canExecute(
 			@Named(IServiceConstants.ACTIVE_SELECTION) @Optional BTSObject selection) {
 		if (selection instanceof BTSCorpusObject && !(selection instanceof BTSAnnotation)) {
-			String dbCollectionName = String.format("%s_%s",
-					selection.getDBCollectionKey(),
-					((BTSCorpusObject) selection).getCorpusPrefix());
-			System.out.println("evaluating user permissions via permissioncontroller.");
+			String dbCollectionName = navigatorController.getDBCollectionName(
+					(BTSCorpusObject)selection);
 			return permissionController.authenticatedUserMayAddToDBCollection(dbCollectionName);
 		}
 		return false;

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/handlers/AddNewTCObjectHandler.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/handlers/AddNewTCObjectHandler.java
@@ -1,8 +1,10 @@
 package org.bbaw.bts.ui.corpus.handlers;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.bbaw.bts.btsmodel.BTSObject;
+import org.bbaw.bts.core.controller.generalController.PermissionsAndExpressionsEvaluationController;
 import org.bbaw.bts.core.corpus.controller.partController.CorpusNavigatorController;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSAnnotation;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSCorpusObject;
@@ -14,8 +16,12 @@ import org.eclipse.e4.ui.services.IServiceConstants;
 import org.eclipse.e4.ui.services.internal.events.EventBroker;
 import org.eclipse.swt.widgets.Shell;
 
+@SuppressWarnings("restriction")
 public class AddNewTCObjectHandler
 {
+
+	@Inject
+	private PermissionsAndExpressionsEvaluationController permissionController;
 
 	@Execute
 	public void execute(@Named(IServiceConstants.ACTIVE_SELECTION) @Optional BTSCorpusObject selection,
@@ -30,7 +36,14 @@ public class AddNewTCObjectHandler
 	@CanExecute
 	public boolean canExecute(
 			@Named(IServiceConstants.ACTIVE_SELECTION) @Optional BTSObject selection) {
-		return (selection instanceof BTSCorpusObject && !(selection instanceof BTSAnnotation));
+		if (selection instanceof BTSCorpusObject && !(selection instanceof BTSAnnotation)) {
+			String dbCollectionName = String.format("%s_%s",
+					selection.getDBCollectionKey(),
+					((BTSCorpusObject) selection).getCorpusPrefix());
+			System.out.println("evaluating user permissions via permissioncontroller.");
+			return permissionController.authenticatedUserMayAddToDBCollection(dbCollectionName);
+		}
+		return false;
 	}
 
 }

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/handlers/AddNewTextHandler.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/handlers/AddNewTextHandler.java
@@ -41,7 +41,6 @@ public class AddNewTextHandler
 	public boolean canExecute(
 			@Named(IServiceConstants.ACTIVE_SELECTION) @Optional BTSObject selection) {
 		if (selection instanceof BTSCorpusObject && !(selection instanceof BTSAnnotation)) {
-			System.out.println("selected object: "+selection.getClass().getName());
 			String dbCollectionName = navigatorController.getDBCollectionName(
 					(BTSCorpusObject)selection);
 			return permissionController.authenticatedUserMayAddToDBCollection(dbCollectionName);

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/handlers/AddNewTextHandler.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/handlers/AddNewTextHandler.java
@@ -1,8 +1,10 @@
 package org.bbaw.bts.ui.corpus.handlers;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.bbaw.bts.btsmodel.BTSObject;
+import org.bbaw.bts.core.controller.generalController.PermissionsAndExpressionsEvaluationController;
 import org.bbaw.bts.core.corpus.controller.partController.CorpusNavigatorController;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSAnnotation;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSCorpusObject;
@@ -14,8 +16,13 @@ import org.eclipse.e4.ui.services.IServiceConstants;
 import org.eclipse.e4.ui.services.internal.events.EventBroker;
 import org.eclipse.swt.widgets.Shell;
 
+@SuppressWarnings("restriction")
 public class AddNewTextHandler
 {
+
+	@Inject
+	private PermissionsAndExpressionsEvaluationController permissionController;
+
 	@Execute
 	public void execute(@Named(IServiceConstants.ACTIVE_SELECTION) @Optional BTSCorpusObject selection,
 			@Named(IServiceConstants.ACTIVE_SHELL) final Shell shell, EventBroker eventBroker,
@@ -30,7 +37,13 @@ public class AddNewTextHandler
 	@CanExecute
 	public boolean canExecute(
 			@Named(IServiceConstants.ACTIVE_SELECTION) @Optional BTSObject selection) {
-		return (selection instanceof BTSCorpusObject && !(selection instanceof BTSAnnotation));
+		if (selection instanceof BTSCorpusObject && !(selection instanceof BTSAnnotation)) {
+			String dbCollectionName = String.format("%s_%s",
+					selection.getDBCollectionKey(),
+					((BTSCorpusObject)selection).getCorpusPrefix());
+			return permissionController.authenticatedUserMayAddToDBCollection(dbCollectionName);
+		}
+		return false;
 	}
 
 }

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/handlers/AddNewTextHandler.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/handlers/AddNewTextHandler.java
@@ -23,6 +23,9 @@ public class AddNewTextHandler
 	@Inject
 	private PermissionsAndExpressionsEvaluationController permissionController;
 
+	@Inject
+	private CorpusNavigatorController navigatorController;
+
 	@Execute
 	public void execute(@Named(IServiceConstants.ACTIVE_SELECTION) @Optional BTSCorpusObject selection,
 			@Named(IServiceConstants.ACTIVE_SHELL) final Shell shell, EventBroker eventBroker,
@@ -38,9 +41,9 @@ public class AddNewTextHandler
 	public boolean canExecute(
 			@Named(IServiceConstants.ACTIVE_SELECTION) @Optional BTSObject selection) {
 		if (selection instanceof BTSCorpusObject && !(selection instanceof BTSAnnotation)) {
-			String dbCollectionName = String.format("%s_%s",
-					selection.getDBCollectionKey(),
-					((BTSCorpusObject)selection).getCorpusPrefix());
+			System.out.println("selected object: "+selection.getClass().getName());
+			String dbCollectionName = navigatorController.getDBCollectionName(
+					(BTSCorpusObject)selection);
 			return permissionController.authenticatedUserMayAddToDBCollection(dbCollectionName);
 		}
 		return false;

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/CorpusNavigatorPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/CorpusNavigatorPart.java
@@ -118,7 +118,7 @@ public class CorpusNavigatorPart extends NavigatorPart implements ScatteredCachi
 	private ESelectionService selectionService;
 
 	@Inject
-	private PermissionsAndExpressionsEvaluationController evaluationController;
+	private PermissionsAndExpressionsEvaluationController permissionController;
 
 	@Inject
 	private BTSResourceProvider resourceProvider;
@@ -442,7 +442,8 @@ labelProvider));
 			mainTextCorpus = context.get(BTSPluginIDs.PREF_MAIN_CORPUS);
 		}
 		if (selectedTextCorpus != null && selectedTextCorpus.getDBCollectionKey() != null
-				&& (mainTextCorpus == null || !mainTextCorpus.equals(selectedTextCorpus)))
+				&& (mainTextCorpus == null || !mainTextCorpus.equals(selectedTextCorpus))
+				&& (corpusNavigatorController.isWriteable(selectedTextCorpus)))
 		{
 			ConfigurationScope.INSTANCE.getNode("org.bbaw.bts.app").put(BTSPluginIDs.PREF_MAIN_CORPUS_KEY, selectedTextCorpus.getDBCollectionKey()+ "_" + selectedTextCorpus.getCorpusPrefix());
 			// update instance scope so that new value is injected
@@ -466,7 +467,6 @@ labelProvider));
 				logger.error(e);
 			}
 		}
-		
 	}
 
 	private BTSTextCorpus findParentCorpusRecursively(
@@ -765,7 +765,7 @@ labelProvider));
 			loaded = true;
 			loadInput(mainTabItemComp, mainTreeViewer, mainRootNode, false);
 		}
-		evaluationController
+		permissionController
 				.activateDBCollectionContext("corpus");
 	}
 

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/preferences/CorpusSettingsPage.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/preferences/CorpusSettingsPage.java
@@ -167,7 +167,13 @@ public class CorpusSettingsPage extends FieldEditorPreferencePage {
 	{
 
 		corpora = corpusController.listTextCorpora(null);
-		mainCorpusComboViewer.setInput(corpora);
+
+		for (BTSTextCorpus corpus : corpora) {
+			if (corpusController.isWriteable(corpus)) {
+				mainCorpusComboViewer.add(corpus);
+			}
+		}
+
 		List<BTSCorpusObject> availableCorpora = new Vector<BTSCorpusObject>(1);
 
 		List<BTSCorpusObject> chosenCorpora = new Vector<BTSCorpusObject>(1);


### PR DESCRIPTION
In a recent modification [#62], activation of corpora was limited to those a user could actually write on. After re-evaluation, it turned out that this was not the desired behaviour. Instead, any corpus should be allowed to be activated if the user's role on it is *transcriber* or higher, or if it is of visibility *public*. 

In addition, unauthorized creation of new objects should have become less likely due to limitation in *main corpus* selection and enhanced command handlers.