### PR TITLE
Quick fix rubrum color.

### DIFF
--- a/org.bbaw.bts.ui.commons.corpus/src/org/bbaw/bts/ui/commons/corpus/text/BTSAnnotationAnnotation.java
+++ b/org.bbaw.bts.ui.commons.corpus/src/org/bbaw/bts/ui/commons/corpus/text/BTSAnnotationAnnotation.java
@@ -3,14 +3,6 @@ package org.bbaw.bts.ui.commons.corpus.text;
 import org.bbaw.bts.btsmodel.BTSIdentifiableItem;
 import org.bbaw.bts.btsmodel.BTSInterTextReference;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSAnnotation;
-import org.bbaw.bts.ui.resources.BTSResourceProvider;
-import org.eclipse.jface.text.source.ImageUtilities;
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.graphics.GC;
-import org.eclipse.swt.graphics.Image;
-import org.eclipse.swt.graphics.Rectangle;
-import org.eclipse.swt.widgets.Canvas;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.xtext.ui.editor.model.IXtextDocument;
 import org.eclipse.xtext.validation.Issue;
 
@@ -48,10 +40,12 @@ public class BTSAnnotationAnnotation extends BTSModelAnnotation {
 	}
 	
 	private void expandType(String type) {
-		if (getRelatingObject().getType() != null) {
-			type += "." + getRelatingObject().getType();
-			if (getRelatingObject().getSubtype() != null) {
-				type += "." + getRelatingObject().getSubtype();
+		if (!type.startsWith(TYPE_RUBRUM)) {
+			if (getRelatingObject().getType() != null) {
+				type += "." + getRelatingObject().getType();
+				if (getRelatingObject().getSubtype() != null) {
+					type += "." + getRelatingObject().getSubtype();
+				}
 			}
 		}
 		setType(type);

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
@@ -317,9 +317,11 @@ public class AnnotationsPart implements EventHandler {
 	@Optional
 	void eventReceivedRelatingObjectsLoaded(
 			@EventTopic("event_text_relating_objects/*") final BTSRelatingObjectsLoadingEvent event) {
-		parentObject = event.getObject();
-		queryId = "relations.objectId-" + parentObject.get_id();
 		if (event != null) {
+			parentObject = event.getObject();
+			if (parentObject != null) {
+				queryId = "relations.objectId-" + parentObject.get_id();
+			}			
 			this.relatingObjectsEvent = event;
 			sync.syncExec(new Runnable() {
 				public void run() {


### PR DESCRIPTION
Because of incorrect initialization of type identifier, new rubra created by text editor command handler could not be covered by the respective annotation strategy in transliteration editor source viewer. This could be fixed very easily.