### PR TITLE
Fix various false write permissions in edit dialogs.

### DIFF
--- a/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
+++ b/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
@@ -10,7 +10,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import org.bbaw.bts.btsmodel.BTSDBBaseObject;
-import org.bbaw.bts.btsmodel.BTSDBCollectionRoleDesc;
 import org.bbaw.bts.btsmodel.BTSObject;
 import org.bbaw.bts.btsmodel.BTSProject;
 import org.bbaw.bts.btsmodel.BTSProjectDBCollection;

--- a/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
+++ b/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
@@ -48,10 +48,6 @@ public class PermissionsAndExpressionsEvaluationControllerImpl implements
 
 	@Inject
 	private IEventBroker eventBroker;
-	
-	private static final String FALSE = "false";
-
-	private static final String TRUE = "true";
 
 	private static final long LOCKING_DELAY = 600;
 

--- a/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
+++ b/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/PermissionsAndExpressionsEvaluationControllerImpl.java
@@ -662,7 +662,30 @@ public class PermissionsAndExpressionsEvaluationControllerImpl implements
 			}
 		}
 		return false;
-		
+	}
+
+	@Override
+	public boolean userMayCommentOnObject(BTSUser user, BTSObject object) {
+		if (user == null || object == null) {
+			return false;
+		} else {
+			if (userContextRole != null) {
+				if (userContextRole.equals(BTSCoreConstants.USER_ROLE_ADMINS)) {
+					return true;
+				}
+				if (userContextRole.equals(BTSCoreConstants.USER_ROLE_EDITORS)) {
+					if (object.getVisibility().equals(BTSCoreConstants.VISIBILITY_PUBLIC)) {
+						return true;
+					} else {
+						return evaluationService.userIsMember(user, object.getUpdaters());
+					}
+				}
+				if (userContextRole.equals(BTSCoreConstants.USER_ROLE_RESEARCHERS)) {
+					return evaluationService.userIsMember(user, object.getUpdaters());
+				}
+			}
+		}
+		return false;
 	}
 
 	private BTSProjectDBCollection getDBCollection(String dbCollectionName) {

--- a/org.bbaw.bts.core.controller/src/org/bbaw/bts/core/controller/generalController/PermissionsAndExpressionsEvaluationController.java
+++ b/org.bbaw.bts.core.controller/src/org/bbaw/bts/core/controller/generalController/PermissionsAndExpressionsEvaluationController.java
@@ -127,5 +127,7 @@ public interface PermissionsAndExpressionsEvaluationController {
 
 	boolean authenticatedUserMayDeleteUserOrUserGroup(BTSObject object);
 
+	boolean userMayCommentOnObject(BTSUser user, BTSObject object);
+
 
 }

--- a/org.bbaw.bts.core.dao.couchDB/src/org/bbaw/bts/dao/couchDB/impl/Backend2ClientUpdateDaoImpl.java
+++ b/org.bbaw.bts.core.dao.couchDB/src/org/bbaw/bts/dao/couchDB/impl/Backend2ClientUpdateDaoImpl.java
@@ -88,8 +88,8 @@ public class Backend2ClientUpdateDaoImpl implements Backend2ClientUpdateDao {
 		notification.setDbCollection(dbCollection);
 		if (feed.isDeleted()) {
 			notification.setDeleted(true);
-			logger.info("Notify Listener object is deleted. object id: "
-					+ docId);
+			//logger.info("Notify Listener object is deleted. object id: "
+			//		+ docId);
 		} else
 		// object not deleted
 		{

--- a/org.bbaw.bts.ui.commons.corpus/src/org/bbaw/bts/ui/commons/corpus/events/BTSRelatingObjectsLoadingEvent.java
+++ b/org.bbaw.bts.ui.commons.corpus/src/org/bbaw/bts/ui/commons/corpus/events/BTSRelatingObjectsLoadingEvent.java
@@ -4,13 +4,14 @@ import java.util.List;
 import java.util.Vector;
 
 import org.bbaw.bts.btsmodel.BTSObject;
+import org.bbaw.bts.corpus.btsCorpusModel.BTSCorpusObject;
 
 public class BTSRelatingObjectsLoadingEvent {
 	private List<BTSObject> relatingObjects = new Vector<BTSObject>(4);
 	
-	private BTSObject object;
+	private BTSCorpusObject object;
 
-	public BTSRelatingObjectsLoadingEvent(BTSObject object) {
+	public BTSRelatingObjectsLoadingEvent(BTSCorpusObject object) {
 		this.object = object;
 	}
 
@@ -22,11 +23,11 @@ public class BTSRelatingObjectsLoadingEvent {
 		this.relatingObjects = relatingObjects;
 	}
 
-	public BTSObject getObject() {
+	public BTSCorpusObject getObject() {
 		return object;
 	}
 
-	public void setObject(BTSObject object) {
+	public void setObject(BTSCorpusObject object) {
 		this.object = object;
 	}
 

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/dialogs/PassportEditorDialog.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/dialogs/PassportEditorDialog.java
@@ -1,8 +1,10 @@
 package org.bbaw.bts.ui.corpus.dialogs;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.bbaw.bts.btsmodel.BTSObject;
+import org.bbaw.bts.core.commons.BTSCoreConstants;
 import org.bbaw.bts.core.corpus.controller.partController.CorpusNavigatorController;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSCorpusObject;
 import org.bbaw.bts.ui.corpus.parts.PassportEditorPart;
@@ -36,7 +38,9 @@ public class PassportEditorDialog extends TitleAreaDialog {
 
 	private Button okButton;
 
-	private boolean editable = true;
+	@Inject
+	@Named(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT)
+	private boolean editable;
 	/**
 	 * Create the dialog.
 	 * @param parentShell
@@ -69,6 +73,7 @@ public class PassportEditorDialog extends TitleAreaDialog {
 		{
 			corpusNavigator.checkAndFullyLoad((BTSCorpusObject) selectionObject, false);
 		}
+		setEditable(editable);
 		
 		IEclipseContext child = context.createChild("passportEditorDialog");
 		child.set(Composite.class, composite);

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
@@ -120,7 +120,7 @@ public class AnnotationsPart implements EventHandler {
 
 	protected boolean selfselection;
 
-	private BTSObject parentObject;
+	private BTSCorpusObject parentObject;
 
 	private boolean allRelatedObjectsShowed;
 
@@ -826,5 +826,9 @@ public class AnnotationsPart implements EventHandler {
 			objects.add(rog.getObject());
 		}
 		return objects.toArray(new BTSObject[objects.size()]);
+	}
+
+	public BTSCorpusObject getCorpusObject() {
+		return parentObject;
 	}
 }

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
@@ -466,6 +466,9 @@ public class AnnotationsPart implements EventHandler {
 		child.set(Composite.class, composite);
 		child.set(AnnotationsPart.class, this);
 		child.set(BTSObject.class, (BTSObject) o);
+		child.set(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT, 
+				permissionsController.userMayEditObject(permissionsController.getAuthenticatedUser(), o));
+
 		if (o instanceof BTSAnnotation)
 		{
 			if (BTSConstants.ANNOTATION_RUBRUM.equalsIgnoreCase(o.getType()))

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/AnnotationsPart.java
@@ -467,7 +467,8 @@ public class AnnotationsPart implements EventHandler {
 		child.set(AnnotationsPart.class, this);
 		child.set(BTSObject.class, (BTSObject) o);
 		child.set(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT, 
-				permissionsController.userMayEditObject(permissionsController.getAuthenticatedUser(), o));
+				permissionsController.userMayEditObject(
+						permissionsController.getAuthenticatedUser(), o));
 
 		if (o instanceof BTSAnnotation)
 		{

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroup.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroup.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.Vector;
 
 import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.bbaw.bts.btsmodel.BTSIdentifiableItem;
 import org.bbaw.bts.btsmodel.BTSInterTextReference;
@@ -86,6 +88,9 @@ public abstract class RelatedObjectGroup extends Composite{
 
 	@Inject
 	protected Logger logger;
+
+	private boolean mayEditObject = false;
+
 
 	@Inject
 	public RelatedObjectGroup(Composite parent, BTSObject object) {
@@ -210,6 +215,12 @@ public abstract class RelatedObjectGroup extends Composite{
 		this.layout();
 	}
 
+	@PreDestroy
+	public void preDestroy() {
+		// TODO dispose of all that stuff
+		context.dispose();
+	}
+
 	protected abstract void addButtons(Composite composite);
 
 	protected abstract void fillContentComposite(Composite composite);
@@ -220,27 +231,25 @@ public abstract class RelatedObjectGroup extends Composite{
 		addButton.setImage(resourceProvider.getImage(Display.getCurrent(), BTSResourceProvider.IMG_RELATION_ADD));
 		addButton.setToolTipText("Add Current Text Selection as Reference");
 		addButton.setLayoutData(new RowData());
-		addButton.addMouseListener(new MouseAdapter() {
+		if (mayEditObject) {
+			addButton.addMouseListener(new MouseAdapter() {
 
-			@Override
-			public void mouseDown(MouseEvent e) {
-				if (mayEdit())
-				{
+				@Override
+				public void mouseDown(MouseEvent e) {
 					Label l = (Label) e.getSource();
 					l.setBackground(BTSUIConstants.VIEW_BACKGROUND_LABEL_PRESSED);
 				}
-			}
 
-			@Override
-			public void mouseUp(MouseEvent e) {
-				if (mayEdit())
-				{
+				@Override
+				public void mouseUp(MouseEvent e) {
 					Label l = (Label) e.getSource();
 					l.setBackground(l.getParent().getBackground());
 					addReference();
 				}
-			}
-		});
+			});
+		} else {
+			addButton.setEnabled(false);
+		}
 		
 		
 		/*Label editButton = new Label(composite, SWT.PUSH);
@@ -273,27 +282,25 @@ public abstract class RelatedObjectGroup extends Composite{
 		delButton.setImage(resourceProvider.getImage(Display.getCurrent(), BTSResourceProvider.IMG_RELATION_DELETE));
 		delButton.setToolTipText("Remove Current Reference");
 		delButton.setLayoutData(new RowData());
-		delButton.addMouseListener(new MouseAdapter() {
+		if (mayEditObject) {
+			delButton.addMouseListener(new MouseAdapter() {
 
-			@Override
-			public void mouseDown(MouseEvent e) {
-				if (mayEdit())
-				{
+				@Override
+				public void mouseDown(MouseEvent e) {
 					Label l = (Label) e.getSource();
 					l.setBackground(BTSUIConstants.VIEW_BACKGROUND_LABEL_PRESSED);
 				}
-			}
 
-			@Override
-			public void mouseUp(MouseEvent e) {
-				if (mayEdit())
-				{
+				@Override
+				public void mouseUp(MouseEvent e) {
 					Label l = (Label) e.getSource();
 					l.setBackground(l.getParent().getBackground());
 					removeReference();
 				}
-			}
-		});
+			});
+		} else {
+			delButton.setEnabled(false);
+		}
 
 		
 	}

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroup.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroup.java
@@ -44,6 +44,7 @@ import org.eclipse.swt.widgets.ExpandItem;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Shell;
 
 public abstract class RelatedObjectGroup extends Composite{
 
@@ -297,8 +298,30 @@ public abstract class RelatedObjectGroup extends Composite{
 		
 	}
 
-	protected boolean mayEdit() {
-		return permissionsController.authenticatedUserMayEditObject(object);
+	/**
+	 * Appends new child node to current {@link IEclipseContext}, populates
+	 * it with the related object this group represents and sets an editable
+	 * flag under {@link BTSCoreConstants#CORE_EXPRESSION_MAY_EDIT} that
+	 * is true if either the related object itself or the text it has been
+	 * loaded for can be modified by current user.
+	 *
+	 * @return context child node
+	 */
+	protected IEclipseContext createDialogChildContext() {
+		IEclipseContext child = context.createChild();
+		child.set(BTSObject.class, (BTSObject) getObject());
+		child.set(Shell.class, new Shell());
+
+		boolean editable = permissionsController.userMayEditObject(
+				permissionsController.getAuthenticatedUser(),
+				object);
+		editable |= permissionsController.userMayEditObject(
+				permissionsController.getAuthenticatedUser(),
+				parentPart.getCorpusObject());
+
+		child.set(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT, editable);
+
+		return child;
 	}
 
 	protected void editReference() {

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroup.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroup.java
@@ -90,6 +90,8 @@ public abstract class RelatedObjectGroup extends Composite{
 	@Inject
 	protected Logger logger;
 
+	@Inject
+	@Named(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT)
 	private boolean mayEditObject = false;
 
 
@@ -222,6 +224,10 @@ public abstract class RelatedObjectGroup extends Composite{
 		context.dispose();
 	}
 
+	protected boolean mayEdit() {
+		return mayEditObject;
+	}
+
 	protected abstract void addButtons(Composite composite);
 
 	protected abstract void fillContentComposite(Composite composite);
@@ -232,7 +238,7 @@ public abstract class RelatedObjectGroup extends Composite{
 		addButton.setImage(resourceProvider.getImage(Display.getCurrent(), BTSResourceProvider.IMG_RELATION_ADD));
 		addButton.setToolTipText("Add Current Text Selection as Reference");
 		addButton.setLayoutData(new RowData());
-		if (mayEditObject) {
+		if (mayEdit()) {
 			addButton.addMouseListener(new MouseAdapter() {
 
 				@Override
@@ -283,7 +289,7 @@ public abstract class RelatedObjectGroup extends Composite{
 		delButton.setImage(resourceProvider.getImage(Display.getCurrent(), BTSResourceProvider.IMG_RELATION_DELETE));
 		delButton.setToolTipText("Remove Current Reference");
 		delButton.setLayoutData(new RowData());
-		if (mayEditObject) {
+		if (mayEdit()) {
 			delButton.addMouseListener(new MouseAdapter() {
 
 				@Override
@@ -338,14 +344,6 @@ public abstract class RelatedObjectGroup extends Composite{
 	 * @param obj
 	 */
 	protected abstract void refreshContent(BTSObject obj);
-
-
-	@Inject
-	public void setEditable(@Named(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT) boolean editAnno) {
-		System.out.println("Object: "+object);
-		System.out.println("Can I edit it? "+editAnno);
-		this.mayEditObject = editAnno;
-	}
 
 	protected void editReference() {
 		BTSTextSelectionEvent selectionEvent = parentPart.getTextSelectionEvent();

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupAnnotation.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupAnnotation.java
@@ -28,14 +28,7 @@ public class RelatedObjectGroupAnnotation extends RelatedObjectGroup {
 	protected void addButtons(Composite composite) {
 		Label editButton = new Label(composite, SWT.PUSH);
 		editButton.setImage(resourceProvider.getImage(Display.getCurrent(), BTSResourceProvider.IMG_EDIT));
-		if (mayEdit())
-		{
-			editButton.setToolTipText("Edit Annotation");
-		}
-		else
-		{
-			editButton.setToolTipText("Open Annotation");
-		}
+		editButton.setToolTipText("Open Annotation");
 		editButton.setLayoutData(new RowData());
 		editButton.addMouseListener(new MouseAdapter() {
 
@@ -57,13 +50,10 @@ public class RelatedObjectGroupAnnotation extends RelatedObjectGroup {
 	}
 
 	protected void editObject() {
-		IEclipseContext child = context.createChild();
-		child.set(BTSObject.class, (BTSObject) getObject());
-		child.set(Shell.class, new Shell());
+		IEclipseContext child = createDialogChildContext();
 		
 		PassportEditorDialog dialog = ContextInjectionFactory.make(
 				PassportEditorDialog.class, child);
-		dialog.setEditable(mayEdit());
 
 		if (dialog.open() == SWT.OK)
 			refreshContent((BTSObject) getObject());

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupAnnotation.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupAnnotation.java
@@ -8,6 +8,7 @@ import org.bbaw.bts.ui.corpus.dialogs.PassportEditorDialog;
 import org.bbaw.bts.ui.resources.BTSResourceProvider;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
@@ -49,20 +50,15 @@ public class RelatedObjectGroupAnnotation extends RelatedObjectGroup {
 
 	}
 
-	protected void editObject() {
-		IEclipseContext child = createDialogChildContext();
-		
-		PassportEditorDialog dialog = ContextInjectionFactory.make(
-				PassportEditorDialog.class, child);
 
-		if (dialog.open() == SWT.OK)
-			refreshContent((BTSObject) getObject());
-
-		child.dispose();
-		
+	@Override
+	protected Dialog createEditorDialog() {
+		return ContextInjectionFactory.make(
+				PassportEditorDialog.class, context);
 	}
 
-	private void refreshContent(BTSObject object) {
+	@Override
+	protected void refreshContent(BTSObject object) {
 		setExpandItemTitle(object.getName());
 	}
 

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupComment.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupComment.java
@@ -41,14 +41,7 @@ public class RelatedObjectGroupComment extends RelatedObjectGroup {
 	protected void addButtons(Composite composite) {
 		Label editButton = new Label(composite, SWT.PUSH);
 		editButton.setImage(resourceProvider.getImage(Display.getCurrent(), BTSResourceProvider.IMG_EDIT));
-		if (mayEdit())
-		{
-			editButton.setToolTipText("Edit Comment");
-		}
-		else
-		{
-			editButton.setToolTipText("Open Comment");
-		}
+		editButton.setToolTipText("Open Comment");
 		editButton.setLayoutData(new RowData());
 		editButton.addMouseListener(new MouseAdapter() {
 
@@ -69,20 +62,20 @@ public class RelatedObjectGroupComment extends RelatedObjectGroup {
 	}
 
 	protected void editObject() {
-		IEclipseContext child = context.createChild();
-		child.set(BTSComment.class, (BTSComment) getObject());
-		child.set(Shell.class, new Shell());
+		IEclipseContext child = createDialogChildContext();
+		child.set(BTSComment.class, (BTSComment)getObject());
 		
 		CommentEditorDialog dialog = ContextInjectionFactory.make(
 				CommentEditorDialog.class, child);
 
-		if (dialog.open() == dialog.OK) {
-			refreschContent((BTSComment) getObject());
+		if (dialog.open() == SWT.OK) {
+			refreshContent((BTSComment) getObject());
 		}
 		
+		child.dispose();
 	}
 
-	private void refreschContent(BTSComment object) {
+	private void refreshContent(BTSComment object) {
 		if (object.getComment() != null) commentText.setText(object.getComment());
 		if (object.getName() != null && !"".equals(object.getName())){
 			setExpandItemTitle(object.getName());
@@ -108,7 +101,7 @@ public class RelatedObjectGroupComment extends RelatedObjectGroup {
 		BTSObject o = getObject();
 		if (o instanceof BTSComment)
 		{
-			refreschContent((BTSComment) getObject());
+			refreshContent((BTSComment) getObject());
 		}
 		commentText.setToolTipText( WordUtils.wrap(((BTSComment) getObject()).getComment(), 60));
 		setExpandBarIcon(resourceProvider.getImage(Display.getCurrent(), BTSResourceProvider.IMG_COMMENT));

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupComment.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupComment.java
@@ -69,6 +69,11 @@ public class RelatedObjectGroupComment extends RelatedObjectGroup {
 
 	@Override
 	protected org.eclipse.jface.dialogs.Dialog createEditorDialog() {
+		// we need to replace flag in context because permission to comment
+		// must be taken into account
+		context.set(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT,
+				mayEdit());
+		context.set(BTSComment.class, (BTSComment)getObject());
 		return ContextInjectionFactory.make(CommentEditorDialog.class, context);
 	};
 	

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupComment.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupComment.java
@@ -1,6 +1,7 @@
  package org.bbaw.bts.ui.corpus.parts.annotationsPart;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.apache.commons.lang.WordUtils;
 import org.bbaw.bts.btsmodel.BTSComment;
@@ -27,9 +28,10 @@ public class RelatedObjectGroupComment extends RelatedObjectGroup {
 
 
 	private Text commentText;
-	
+
 	@Inject
-	private CommentController commentController;
+	@Named(BTSCoreConstants.CORE_EXPRESSION_MAY_COMMENT)
+	private boolean mayCommentObject;
 
 	@Inject
 	public RelatedObjectGroupComment(Composite parent, BTSObject object) {

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupComment.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupComment.java
@@ -62,19 +62,10 @@ public class RelatedObjectGroupComment extends RelatedObjectGroup {
 
 	}
 
-/*	protected void editObject() {
-		IEclipseContext child = createDialogChildContext();
-		child.set(BTSComment.class, (BTSComment)getObject());
-		
-		CommentEditorDialog dialog = ContextInjectionFactory.make(
-				CommentEditorDialog.class, child);
-
-		if (dialog.open() == SWT.OK) {
-			refreshContent((BTSComment) getObject());
-		}
-		
-		child.dispose();
-	}*/
+	@Override
+	protected boolean mayEdit() {
+		return super.mayEdit() || mayCommentObject;
+	}
 
 	@Override
 	protected org.eclipse.jface.dialogs.Dialog createEditorDialog() {

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupComment.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupComment.java
@@ -6,7 +6,7 @@ import org.apache.commons.lang.WordUtils;
 import org.bbaw.bts.btsmodel.BTSComment;
 import org.bbaw.bts.btsmodel.BTSObject;
 import org.bbaw.bts.btsmodel.BTSRevision;
-import org.bbaw.bts.core.controller.generalController.CommentController;
+import org.bbaw.bts.core.commons.BTSCoreConstants;
 import org.bbaw.bts.ui.commons.utils.BTSUIConstants;
 import org.bbaw.bts.ui.main.dialogs.CommentEditorDialog;
 import org.bbaw.bts.ui.resources.BTSResourceProvider;
@@ -21,7 +21,6 @@ import org.eclipse.swt.layout.RowData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 
 public class RelatedObjectGroupComment extends RelatedObjectGroup {
@@ -61,7 +60,7 @@ public class RelatedObjectGroupComment extends RelatedObjectGroup {
 
 	}
 
-	protected void editObject() {
+/*	protected void editObject() {
 		IEclipseContext child = createDialogChildContext();
 		child.set(BTSComment.class, (BTSComment)getObject());
 		
@@ -73,16 +72,23 @@ public class RelatedObjectGroupComment extends RelatedObjectGroup {
 		}
 		
 		child.dispose();
-	}
+	}*/
 
-	private void refreshContent(BTSComment object) {
-		if (object.getComment() != null) commentText.setText(object.getComment());
-		if (object.getName() != null && !"".equals(object.getName())){
-			setExpandItemTitle(object.getName());
+	@Override
+	protected org.eclipse.jface.dialogs.Dialog createEditorDialog() {
+		return ContextInjectionFactory.make(CommentEditorDialog.class, context);
+	};
+	
+	@Override
+	protected void refreshContent(BTSObject obj) {
+		BTSComment comment = (BTSComment)obj;
+		if (comment.getComment() != null) commentText.setText(comment.getComment());
+		if (comment.getName() != null && !"".equals(comment.getName())){
+			setExpandItemTitle(comment.getName());
 		}
 		else
 		{
-			setExpandItemTitle(object.getComment().substring(0, Math.min(object.getComment().length(), TITLE_LENGTH)));
+			setExpandItemTitle(comment.getComment().substring(0, Math.min(comment.getComment().length(), TITLE_LENGTH)));
 		}
 		
 	}

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupImpl.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupImpl.java
@@ -3,9 +3,14 @@ package org.bbaw.bts.ui.corpus.parts.annotationsPart;
 import javax.inject.Inject;
 
 import org.bbaw.bts.btsmodel.BTSObject;
+import org.bbaw.bts.ui.corpus.dialogs.PassportEditorDialog;
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
+import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.swt.widgets.Composite;
 
 public class RelatedObjectGroupImpl extends RelatedObjectGroup {
+	
+	// XXX what??? warum haben wir das?
 
 	@Inject
 	public RelatedObjectGroupImpl(Composite parent, BTSObject object) {
@@ -22,6 +27,18 @@ public class RelatedObjectGroupImpl extends RelatedObjectGroup {
 	protected void fillContentComposite(Composite composite) {
 		// TODO Auto-generated method stub
 		
+	}
+
+	@Override
+	protected void refreshContent(BTSObject obj) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	@Override
+	protected Dialog createEditorDialog() {
+		return ContextInjectionFactory.make(
+				PassportEditorDialog.class, context);
 	}
 
 }

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupRubrum.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupRubrum.java
@@ -2,22 +2,20 @@ package org.bbaw.bts.ui.corpus.parts.annotationsPart;
 
 import javax.inject.Inject;
 
-import org.bbaw.bts.btsmodel.BTSComment;
 import org.bbaw.bts.btsmodel.BTSObject;
 import org.bbaw.bts.ui.commons.utils.BTSUIConstants;
 import org.bbaw.bts.ui.corpus.dialogs.PassportEditorDialog;
 import org.bbaw.bts.ui.resources.BTSResourceProvider;
 import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IEclipseContext;
+import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
-import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.RowData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Shell;
 
 public class RelatedObjectGroupRubrum extends RelatedObjectGroup {
 
@@ -50,30 +48,23 @@ public class RelatedObjectGroupRubrum extends RelatedObjectGroup {
 		
 	}
 
-	protected void editObject() {
-		IEclipseContext child = createDialogChildContext();
-		
-		PassportEditorDialog dialog = ContextInjectionFactory.make(
-				PassportEditorDialog.class, child);
 
-		if (dialog.open() == SWT.OK) {
-			refreschContent((BTSObject) getObject());
-		}
-		
-		child.dispose();
+	@Override
+	protected Dialog createEditorDialog() {
+		return ContextInjectionFactory.make(
+				PassportEditorDialog.class, context);
 	}
 
-	private void refreschContent(BTSObject object) {
+	@Override
+	protected void refreshContent(BTSObject object) {
 		setGroupTitle("Rubrum");
-
-		
 	}
 
 	@Override
 	protected void fillContentComposite(Composite composite) {
 		setExpandBarIcon(resourceProvider.getImage(Display.getCurrent(), BTSResourceProvider.IMG_RUBRUM));
 		setExpandBarBackground(BTSUIConstants.COLOR_WIHTE);
-		refreschContent((BTSObject) getObject());
+		refreshContent((BTSObject) getObject());
 	}
 
 }

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupRubrum.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupRubrum.java
@@ -30,14 +30,7 @@ public class RelatedObjectGroupRubrum extends RelatedObjectGroup {
 	protected void addButtons(Composite composite) {
 		Label editButton = new Label(composite, SWT.PUSH);
 		editButton.setImage(resourceProvider.getImage(Display.getCurrent(), BTSResourceProvider.IMG_EDIT));
-		if (mayEdit())
-		{
-			editButton.setToolTipText("Edit Rubrum");
-		}
-		else
-		{
-			editButton.setToolTipText("Open Rubrum");
-		}
+		editButton.setToolTipText("Open Rubrum");
 		editButton.setLayoutData(new RowData());
 		editButton.addMouseListener(new MouseAdapter() {
 
@@ -58,18 +51,16 @@ public class RelatedObjectGroupRubrum extends RelatedObjectGroup {
 	}
 
 	protected void editObject() {
-		IEclipseContext child = context.createChild();
-		child.set(BTSObject.class, (BTSObject) getObject());
-		child.set(Shell.class, new Shell());
+		IEclipseContext child = createDialogChildContext();
 		
 		PassportEditorDialog dialog = ContextInjectionFactory.make(
 				PassportEditorDialog.class, child);
-		dialog.setEditable(mayEdit());
 
-		if (dialog.open() == dialog.OK) {
+		if (dialog.open() == SWT.OK) {
 			refreschContent((BTSObject) getObject());
 		}
 		
+		child.dispose();
 	}
 
 	private void refreschContent(BTSObject object) {

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupSubtext.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/annotationsPart/RelatedObjectGroupSubtext.java
@@ -4,16 +4,15 @@ import java.awt.image.BufferedImage;
 
 import javax.inject.Inject;
 
-import org.bbaw.bts.btsmodel.BTSComment;
 import org.bbaw.bts.btsmodel.BTSObject;
 import org.bbaw.bts.btsmodel.BTSRevision;
 import org.bbaw.bts.core.corpus.controller.partController.BTSTextEditorController;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSText;
 import org.bbaw.bts.ui.commons.utils.BTSUIConstants;
 import org.bbaw.bts.ui.resources.BTSResourceProvider;
+import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.source.AnnotationModel;
-import org.eclipse.jface.text.source.IAnnotationModel;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.PaintEvent;
 import org.eclipse.swt.events.PaintListener;
@@ -30,7 +29,6 @@ public class RelatedObjectGroupSubtext extends RelatedObjectGroup {
 
 	@Inject
 	private BTSTextEditorController textController;
-	private Document document;
 	private Text transcriptionText;
 	private Control canvas;
 	@Inject
@@ -61,7 +59,6 @@ public class RelatedObjectGroupSubtext extends RelatedObjectGroup {
 		if (o instanceof BTSText)
 		{
 			Document doc = new Document();
-			this.document = doc;
 
 			AnnotationModel model = new AnnotationModel();
 
@@ -109,5 +106,15 @@ public class RelatedObjectGroupSubtext extends RelatedObjectGroup {
 		{
 			transcriptionText.setBackground(color);
 		}
+	}
+
+	@Override
+	protected Dialog createEditorDialog() {
+		return null;
+	}
+
+	@Override
+	protected void refreshContent(BTSObject obj) {
+		//
 	}
 }

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/passportEditor/PassportEntryItemEditor.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/passportEditor/PassportEntryItemEditor.java
@@ -14,6 +14,7 @@ import org.bbaw.bts.commons.BTSConstants;
 import org.bbaw.bts.core.commons.BTSCoreConstants;
 import org.bbaw.bts.core.controller.generalController.BTSConfigurationController;
 import org.bbaw.bts.core.controller.generalController.GeneralBTSObjectController;
+import org.bbaw.bts.core.controller.generalController.PermissionsAndExpressionsEvaluationController;
 import org.bbaw.bts.core.corpus.controller.generalController.PassportConfigurationController;
 import org.bbaw.bts.core.corpus.controller.partController.PassportEditorPartController;
 import org.bbaw.bts.core.corpus.controller.partController.ThsNavigatorController;
@@ -154,6 +155,9 @@ public class PassportEntryItemEditor extends PassportEntryEditorComposite {
 	private Text text;
 	@Inject
 	private PassportConfigurationController passportConfigurationController;
+	
+	@Inject
+	private PermissionsAndExpressionsEvaluationController permissionController;
 
 	@Inject
 	public PassportEntryItemEditor(Composite parent) {
@@ -743,6 +747,10 @@ public class PassportEntryItemEditor extends PassportEntryEditorComposite {
 					IEclipseContext child = context.createChild();
 					child.set(BTSObject.class, btso);
 					child.set(Shell.class, new Shell());
+					child.set(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT, 
+							permissionController.userMayEditObject(
+									permissionController.getAuthenticatedUser(), 
+									btso));
 					
 					PassportEditorDialog dialog = ContextInjectionFactory.make(
 							PassportEditorDialog.class, child);

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/dialogs/CommentEditorDialog.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/dialogs/CommentEditorDialog.java
@@ -83,10 +83,6 @@ public class CommentEditorDialog extends TitleAreaDialog {
 	@Named(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT)
 	private boolean editable;
 
-	@Inject
-	@Named(BTSCoreConstants.CORE_EXPRESSION_MAY_COMMENT)
-	private boolean mayComment;
-
 	/**
 	 * Create the dialog.
 	 * @param parentShell
@@ -189,7 +185,7 @@ public class CommentEditorDialog extends TitleAreaDialog {
 		// comment can be modified if user is in its updaters list
 		// this will only work if permission to comment text/corpus object
 		// has been put into context under CORE_EXPRESSIONS_MAY_COMMENT
-		setEditable(editable || mayComment);
+		setEditable(editable);
 		
 	}
 

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/dialogs/CommentEditorDialog.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/dialogs/CommentEditorDialog.java
@@ -5,10 +5,12 @@ import java.util.HashSet;
 import java.util.Set;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.bbaw.bts.btsmodel.BTSComment;
 import org.bbaw.bts.btsmodel.BTSObject;
 import org.bbaw.bts.btsmodel.BtsmodelPackage;
+import org.bbaw.bts.core.commons.BTSCoreConstants;
 import org.bbaw.bts.core.controller.generalController.CommentController;
 import org.bbaw.bts.core.controller.generalController.EditingDomainController;
 import org.bbaw.bts.core.controller.generalController.PermissionsAndExpressionsEvaluationController;
@@ -76,7 +78,14 @@ public class CommentEditorDialog extends TitleAreaDialog {
 	private boolean dirty;
 	private Composite container;
 	private Composite innerCompositeRelations;
+
+	@Inject
+	@Named(BTSCoreConstants.CORE_EXPRESSION_MAY_EDIT)
 	private boolean editable;
+
+	@Inject
+	@Named(BTSCoreConstants.CORE_EXPRESSION_MAY_COMMENT)
+	private boolean mayComment;
 
 	/**
 	 * Create the dialog.
@@ -176,16 +185,26 @@ public class CommentEditorDialog extends TitleAreaDialog {
 				getCommandStackListener());
 		
 		loadRelations();
-		checkRightsAndSetEditable();
+
+		// comment can be modified if user is in its updaters list
+		// this will only work if permission to comment text/corpus object
+		// has been put into context under CORE_EXPRESSIONS_MAY_COMMENT
+		setEditable(editable || mayComment);
 		
 	}
 
-	private void checkRightsAndSetEditable() {
-		editable = permissionsController.userMayEditObject(
-				permissionsController.getAuthenticatedUser(), comment);
+	/**
+	 * Set editable flag and update controls accordingly.
+	 * @param editable
+	 */
+	public void setEditable(boolean editable) {
+		this.editable = editable;
 		txtTitletxt.setEditable(editable);
 		txtCommenttxt.setEditable(editable);
 		relationsEditor.setEnabled(editable);
+		try {
+			this.getButton(IDialogConstants.OK_ID).setEnabled(editable);
+		} catch (Exception e) {}
 	}
 
 	private CommandStackListener getCommandStackListener() {


### PR DESCRIPTION
Add calls to `PermissionsAndEvaluationController` when opening edit dialogs like passport/comment editor dialog, write write permission flag to context. This should fix problems referred to in #93.