### PR TITLE
Fix flawed determination of database location.

### DIFF
--- a/org.bbaw.bts.commons.fsaccess/src/org/bbaw/bts/commons/fsaccess/BTSContstantsPlatformSpecific.java
+++ b/org.bbaw.bts.commons.fsaccess/src/org/bbaw/bts/commons/fsaccess/BTSContstantsPlatformSpecific.java
@@ -147,24 +147,4 @@ public class BTSContstantsPlatformSpecific {
 		return userEnvPath;
 	}
 
-	
-	/** Returns the Database Installation directory within the given btsInstallation directory. 
-	 * DBInstallationDir is the directory where the folder 'CouchDB' is located. 
-	 * Under an installation of CouchDB using e.g. msi-installer that would be the Programs/Apache Software...
-	 * In bts case it is the <code>btsInstallationDir</code>/dbdir
-	 * 
-	 * @deprecated
-	 * 
-	 * @param btsInsallationDir BTS Installation Directory
-	 * @return Database Installation Directory
-	 */
-	public static String getDBInstallationDir(String btsInsallationDir) {
-		if (btsInsallationDir == null)
-		{
-			btsInsallationDir = getInstallationDir();
-		}
-		String dbdir = btsInsallationDir + BTSContstantsPlatformSpecific.FS + BTSConstants.DB_DIR;
-
-		return dbdir;
-	}
 }

--- a/org.bbaw.bts.commons.libs.elasticsearch/.classpath
+++ b/org.bbaw.bts.commons.libs.elasticsearch/.classpath
@@ -5,7 +5,7 @@
 	<classpathentry exported="true" kind="lib" path="libs/apache-log4j-extras-1.2.17.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/asm-4.1.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/asm-commons-4.1.jar"/>
-	<classpathentry exported="true" kind="lib" path="libs/elasticsearch-1.7.3.jar" sourcepath="C:/IT/BTS/dev/elasticsearch_sources/elasticsearch-1.7.3-sources.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/elasticsearch-1.7.3.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/groovy-all-2.4.4.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/jna-4.1.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="libs/jts-1.13.jar"/>

--- a/org.bbaw.bts.commons/src/org/bbaw/bts/commons/BTSConstants.java
+++ b/org.bbaw.bts.commons/src/org/bbaw/bts/commons/BTSConstants.java
@@ -95,7 +95,6 @@ public class BTSConstants
 			BTSConstants.ANNOTATION, BTSConstants.CORPUS_OBJECT,
 			BTSConstants.IMAGE, BTSConstants.WLIST_ENTRY, BTSConstants.TEXT,
 			BTSConstants.TEXT_CORPUS, BTSConstants.THS_ENTRY , BTSConstants.COMMENT};
-	public static final String DB_DIR = "dbdir";
 	public static final String DEFAULT_LOCAL_DB_URL_PORT = "9086";//"6984";//
 	public static final String DEFAULT_LOCAL_DB_URL_HOST = "127.0.0.1";
 	public static final String DEFAULT_LOCAL_DB_URL_PROTOCOL = "http";

--- a/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/ApplicationStartupControllerImpl.java
+++ b/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/ApplicationStartupControllerImpl.java
@@ -196,11 +196,16 @@ public class ApplicationStartupControllerImpl implements
 		logger.info("db_installation_dir " + db_installation_dir);
 
 		if (db_installation_dir == null || "".equals(db_installation_dir)) {
-			String btsInsallationDir = BTSContstantsPlatformSpecific.getInstallationDir();
+			/// XXX retrieve db installation location from user by opening a dialog when in doubt
+			// XXX or at least make "dbdir" a constant amk
+			String btsInsallationDir = BTSContstantsPlatformSpecific.getInstallationDir()
+					+ BTSContstantsPlatformSpecific.FS + "dbdir";
 			logger.info("btsInsallationDir " + btsInsallationDir);
+			
+			// XXX if we don't know database location, we need to find out.
+			// if its not at expected location (installdir/dbdir/) then
+			// we have to ask the user
 
-			db_installation_dir = BTSContstantsPlatformSpecific
-					.getDBInstallationDir(btsInsallationDir);
 			prefs.put(BTSPluginIDs.PREF_DB_DIR, db_installation_dir);
 			try {
 				prefs.flush();

--- a/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/ApplicationStartupControllerImpl.java
+++ b/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/ApplicationStartupControllerImpl.java
@@ -198,17 +198,18 @@ public class ApplicationStartupControllerImpl implements
 		if (db_installation_dir == null || "".equals(db_installation_dir)) {
 			/// XXX retrieve db installation location from user by opening a dialog when in doubt
 			// XXX or at least make "dbdir" a constant amk
-			String btsInsallationDir = BTSContstantsPlatformSpecific.getInstallationDir()
+			String btsInstallationDir = BTSContstantsPlatformSpecific.getInstallationDir()
 					+ BTSContstantsPlatformSpecific.FS + "dbdir";
-			logger.info("btsInsallationDir " + btsInsallationDir);
+			logger.info("btsInstallationDir " + btsInstallationDir);
 			
 			// XXX if we don't know database location, we need to find out.
 			// if its not at expected location (installdir/dbdir/) then
 			// we have to ask the user
 
-			prefs.put(BTSPluginIDs.PREF_DB_DIR, db_installation_dir);
+			prefs.put(BTSPluginIDs.PREF_DB_DIR, btsInstallationDir);
 			try {
 				prefs.flush();
+				db_installation_dir = btsInstallationDir;
 			} catch (BackingStoreException e) {
 				logger.error(e);
 			}

--- a/org.bbaw.bts.core.dao.couchDB/src/org/bbaw/bts/dao/couchDB/impl/DBConnectionProviderImpl.java
+++ b/org.bbaw.bts.core.dao.couchDB/src/org/bbaw/bts/dao/couchDB/impl/DBConnectionProviderImpl.java
@@ -362,14 +362,10 @@ public class DBConnectionProviderImpl implements DBConnectionProvider
 				
 				//node client
 				IEclipsePreferences preferences = ConfigurationScope.INSTANCE.getNode("org.bbaw.bts.app");
-				String installDir = null;
-				try {
-					installDir = org.bbaw.bts.commons.fsaccess.BTSContstantsPlatformSpecific.getDBInstallationDir(null);
-				} catch (Exception e) {
-					// TODO Auto-generated catch block
-					e.printStackTrace();
-				}
+				String installDir = org.bbaw.bts.commons.fsaccess.BTSContstantsPlatformSpecific.getInstallationDir();
+
 				String dbdir = preferences.get(BTSPluginIDs.PREF_DB_DIR, installDir);
+
 				ImmutableSettings.Builder elasticsearchSettings = ImmutableSettings.settingsBuilder()
 //		                .put("http.enabled", ("true".equals(search_http_enabled)))
 						//FIXME make dynamic

--- a/org.bbaw.bts.db.couchdb/src/org/bbaw/bts/db/couchdb/impl/CouchDBManager.java
+++ b/org.bbaw.bts.db.couchdb/src/org/bbaw/bts/db/couchdb/impl/CouchDBManager.java
@@ -2211,8 +2211,7 @@ public class CouchDBManager implements DBManager {
 	@Override
 	public boolean changeAuthenticationDBAdmin(String userName, String password)
 			throws FileNotFoundException {
-		String localIni = getOSCouchDBLocalIniFile(BTSContstantsPlatformSpecific
-				.getDBInstallationDir(BTSContstantsPlatformSpecific.getInstallationDir()));
+		String localIni = getOSCouchDBLocalIniFile(dbDir);
 		File localIniFile = new File(localIni);
 		if (localIniFile.exists()) {
 			Scanner scanner = new Scanner(localIniFile);

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/wizards/installation/InstallationWizard.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/wizards/installation/InstallationWizard.java
@@ -184,6 +184,7 @@ public class InstallationWizard extends Wizard {
 		preferences.put(BTSPluginIDs.PREF_LOCAL_DB_URL, localUrl);
 
 		if (welcomePage.isConnectToServer()) {
+			// XXX
 			userController.setAuthenticatedUser(getUser());
 
 			serverURL = connectServerPage.getServerURL();


### PR DESCRIPTION
A method for determination of database location in file system has previously been set to deprecated but is still in use. In order to avoid confusion, this method must go.