### PR TITLE
Final preparations for release 3.1.1.

### DIFF
--- a/com.opcoach.e4.preferences/pom.xml
+++ b/com.opcoach.e4.preferences/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <artifactId>com.opcoach.e4.preferences</artifactId>
   <version>1.0.0-SNAPSHOT</version>

--- a/org.bbaw.bts.app.feature/feature.xml
+++ b/org.bbaw.bts.app.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.bbaw.bts.app.feature"
       label="Berlin Text System Core Application"
-      version="3.1.0.qualifier"
+      version="3.1.1.qualifier"
       provider-name="BBAW"
       os="linux,macosx,win32"
       ws="carbon,cocoa,gtk,win32"

--- a/org.bbaw.bts.app.feature/pom.xml
+++ b/org.bbaw.bts.app.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.app.feature</artifactId>

--- a/org.bbaw.bts.app.feature/pom.xml
+++ b/org.bbaw.bts.app.feature/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.app.feature</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-feature</packaging>
 </project>

--- a/org.bbaw.bts.app.login/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.app.login/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: ApplicationLogin
 Bundle-SymbolicName: org.bbaw.bts.app.login;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: BBAW
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.e4.ui.workbench;bundle-version="0.10.2",

--- a/org.bbaw.bts.app.login/pom.xml
+++ b/org.bbaw.bts.app.login/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.app.login</artifactId>

--- a/org.bbaw.bts.app.login/pom.xml
+++ b/org.bbaw.bts.app.login/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.app.login</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.app.product/org.bbaw.bts.app.product
+++ b/org.bbaw.bts.app.product/org.bbaw.bts.app.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Berlin Text System" uid="org.bbaw.bts.app.product" id="org.bbaw.bts.app.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="3.1.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Berlin Text System" uid="org.bbaw.bts.app.product" id="org.bbaw.bts.app.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="3.1.1.qualifier" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -127,7 +127,7 @@
    </plugins>
 
    <features>
-      <feature id="org.bbaw.bts.app.feature" version="3.1.0.qualifier"/>
+      <feature id="org.bbaw.bts.app.feature" version="3.1.1.qualifier"/>
       <feature id="org.bbaw.bts.corpus.egy.feature" version="3.1.0.qualifier"/>
    </features>
 

--- a/org.bbaw.bts.app.product/p2.inf
+++ b/org.bbaw.bts.app.product/p2.inf
@@ -1,3 +1,3 @@
 instructions.configure=\
-  addRepository(type:0,location:http${#58}//telota.bbaw.de/bts-update/update-3.x/repository/);\
-  addRepository(type:1,location:http${#58}//telota.bbaw.de/bts-update/update-3.x/repository/);
+  addRepository(type:0,location:http${#58}//telota.bbaw.de/bts-update/update-test/repository/);\
+  addRepository(type:1,location:http${#58}//telota.bbaw.de/bts-update/update-test/repository/);

--- a/org.bbaw.bts.app.product/p2.inf
+++ b/org.bbaw.bts.app.product/p2.inf
@@ -1,3 +1,3 @@
 instructions.configure=\
-  addRepository(type:0,location:http${#58}//telota.bbaw.de/bts-update/update-test/repository/);\
-  addRepository(type:1,location:http${#58}//telota.bbaw.de/bts-update/update-test/repository/);
+  addRepository(type:0,location:http${#58}//telota.bbaw.de/bts-update/update-3.x/repository/);\
+  addRepository(type:1,location:http${#58}//telota.bbaw.de/bts-update/update-3.x/repository/);

--- a/org.bbaw.bts.app.product/pom.xml
+++ b/org.bbaw.bts.app.product/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.bbaw.bts</groupId>
 	<artifactId>org.bbaw.bts.app.product</artifactId>
-	<version>3.1.0-SNAPSHOT</version>
+	<version>3.1.1-SNAPSHOT</version>
 	<packaging>eclipse-repository</packaging>
 
 	<properties>

--- a/org.bbaw.bts.app.product/pom.xml
+++ b/org.bbaw.bts.app.product/pom.xml
@@ -7,7 +7,7 @@
 	<packaging>eclipse-repository</packaging>
 
 	<properties>
-		<tycho.version>0.19.0</tycho.version>
+		<tycho.version>1.0.0</tycho.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/org.bbaw.bts.app.product/pom.xml
+++ b/org.bbaw.bts.app.product/pom.xml
@@ -7,8 +7,8 @@
 	<packaging>eclipse-repository</packaging>
 
 	<properties>
-		<tycho.version>1.0.0</tycho.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<tycho.version>0.19.0</tycho.version>
 	</properties>
 
 	<repositories>
@@ -33,7 +33,7 @@
 
 	<build>
 		<plugins>
-			<plugin>
+			<!--<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>tycho-versions-plugin</artifactId>
 				<version>${tycho.version}</version>
@@ -46,7 +46,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin>-->
 
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
@@ -58,6 +58,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho.version}</version>
 				<configuration>
 					<environments>
 						<environment>

--- a/org.bbaw.bts.app/Application.e4xmi
+++ b/org.bbaw.bts.app/Application.e4xmi
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <application:Application xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:advanced="http://www.eclipse.org/ui/2010/UIModel/application/ui/advanced" xmlns:application="http://www.eclipse.org/ui/2010/UIModel/application" xmlns:basic="http://www.eclipse.org/ui/2010/UIModel/application/ui/basic" xmlns:menu="http://www.eclipse.org/ui/2010/UIModel/application/ui/menu" xmi:id="_oEzH4AA1EeOpmPWG2KRhAA" elementId="org.bbaw.bts.application">
-  <children xsi:type="basic:TrimmedWindow" xmi:id="_oEzH4QA1EeOpmPWG2KRhAA" elementId="org.bbaw.bts.trimmed" label="Berlin Text System 3.1.0" iconURI="platform:/plugin/org.bbaw.bts.app/icons/bts16.bmp" width="1000" height="750">
+  <children xsi:type="basic:TrimmedWindow" xmi:id="_oEzH4QA1EeOpmPWG2KRhAA" elementId="org.bbaw.bts.trimmed" label="Berlin Text System 3.1.1" iconURI="platform:/plugin/org.bbaw.bts.app/icons/bts16.bmp" width="1000" height="750">
     <children xsi:type="advanced:PerspectiveStack" xmi:id="_l1Ug4ADrEeOpmPWG2KRhAA" elementId="org.bbaw.bts.app.perspectivestack.main"/>
     <mainMenu xmi:id="_3KR2AAD1EeOpmPWG2KRhAA" elementId="org.eclipse.ui.menu">
       <children xsi:type="menu:Menu" xmi:id="_N6Q08AD2EeOpmPWG2KRhAA" elementId="org.eclipse.ui.file" label="File">

--- a/org.bbaw.bts.app/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.app/META-INF/MANIFEST.MF
@@ -24,4 +24,4 @@ Import-Package: javax.annotation,
  org.eclipse.jface.resource,
  org.eclipse.swt.graphics
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.app/plugin_customization.ini
+++ b/org.bbaw.bts.app/plugin_customization.ini
@@ -41,7 +41,7 @@ org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP = true
 org.bbaw.bts.app/active_configuration=aaew
 
 ##p2_update_site_url url for software update
-org.bbaw.bts.app/p2_update_site_url=http://telota.bbaw.de/bts-update/update-3.x/repository/
+org.bbaw.bts.app/p2_update_site_url=http://telota.bbaw.de/bts-update/update-test/repository/
 
 
 ## time server

--- a/org.bbaw.bts.app/plugin_customization.ini
+++ b/org.bbaw.bts.app/plugin_customization.ini
@@ -41,7 +41,7 @@ org.eclipse.ui/SHOW_PROGRESS_ON_STARTUP = true
 org.bbaw.bts.app/active_configuration=aaew
 
 ##p2_update_site_url url for software update
-org.bbaw.bts.app/p2_update_site_url=http://telota.bbaw.de/bts-update/update-test/repository/
+org.bbaw.bts.app/p2_update_site_url=http://telota.bbaw.de/bts-update/update-3.x/repository/
 
 
 ## time server

--- a/org.bbaw.bts.app/pom.xml
+++ b/org.bbaw.bts.app/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.app</artifactId>

--- a/org.bbaw.bts.app/pom.xml
+++ b/org.bbaw.bts.app/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.app</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.commons.fsaccess/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.commons.fsaccess/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: BTSFsaccess
 Bundle-SymbolicName: org.bbaw.bts.commons.fsaccess;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Activator: org.bbaw.bts.commons.fsaccess.internal.Activator
 Require-Bundle: org.eclipse.core.runtime
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/org.bbaw.bts.commons.fsaccess/pom.xml
+++ b/org.bbaw.bts.commons.fsaccess/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.commons.fsaccess</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.commons.fsaccess/pom.xml
+++ b/org.bbaw.bts.commons.fsaccess/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.commons.fsaccess</artifactId>

--- a/org.bbaw.bts.commons.libs.elasticsearch/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.commons.libs.elasticsearch/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Elasticsearch
 Bundle-SymbolicName: org.bbaw.bts.commons.libs.elasticsearch
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: .,
  libs/antlr-runtime-3.5.jar,

--- a/org.bbaw.bts.commons.libs.elasticsearch/pom.xml
+++ b/org.bbaw.bts.commons.libs.elasticsearch/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.commons.libs.elasticsearch</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.commons.libs.elasticsearch/pom.xml
+++ b/org.bbaw.bts.commons.libs.elasticsearch/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.commons.libs.elasticsearch</artifactId>

--- a/org.bbaw.bts.commons/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.commons/META-INF/MANIFEST.MF
@@ -15,4 +15,4 @@ Bundle-Activator: org.bbaw.bts.commons.BTSCommonsActivator
 Require-Bundle: org.eclipse.e4.core.services;bundle-version="1.1.0",
  org.eclipse.osgi,
  org.eclipse.core.runtime;bundle-version="3.9.0"
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.commons/pom.xml
+++ b/org.bbaw.bts.commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.commons</artifactId>

--- a/org.bbaw.bts.commons/pom.xml
+++ b/org.bbaw.bts.commons/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.commons</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.commons.corpus.help/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.commons.corpus.help/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: BTS Help Resources
 Bundle-SymbolicName: org.bbaw.bts.core.commons.corpus.help;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Activator: org.bbaw.bts.core.commons.corpus.help.Activator
 Bundle-Vendor: BBAW
 Export-Package: org.bbaw.bts.core.commons.corpus.help

--- a/org.bbaw.bts.core.commons.corpus.help/pom.xml
+++ b/org.bbaw.bts.core.commons.corpus.help/pom.xml
@@ -21,6 +21,6 @@
   <parent>
   	<groupId>org.bbaw.bts</groupId>
   	<artifactId>aaew-bts</artifactId>
-  	<version>3.1.0</version>
+  	<version>3.1.1</version>
   </parent>
 </project>

--- a/org.bbaw.bts.core.commons.corpus.help/pom.xml
+++ b/org.bbaw.bts.core.commons.corpus.help/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.commons.corpus.help</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <name>BTS Help Resources Bundle</name>
   <build>
     <sourceDirectory>src</sourceDirectory>

--- a/org.bbaw.bts.core.commons.corpus/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.commons.corpus/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CorpusCommons
 Bundle-SymbolicName: org.bbaw.bts.core.commons.corpus
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: BBAW
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.bbaw.bts.btsmodel,

--- a/org.bbaw.bts.core.commons.corpus/pom.xml
+++ b/org.bbaw.bts.core.commons.corpus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.commons.corpus</artifactId>

--- a/org.bbaw.bts.core.commons.corpus/pom.xml
+++ b/org.bbaw.bts.core.commons.corpus/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.commons.corpus</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.commons/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.commons/META-INF/MANIFEST.MF
@@ -30,4 +30,4 @@ Import-Package: javax.inject,
 Require-Bundle: org.eclipse.e4.core.di;bundle-version="1.3.0"
 Bundle-ClassPath: lib/commons-net-3.3.jar,
  .
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.core.commons/pom.xml
+++ b/org.bbaw.bts.core.commons/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.commons</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.commons/pom.xml
+++ b/org.bbaw.bts.core.commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.commons</artifactId>

--- a/org.bbaw.bts.core.controller.impl/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.controller.impl/META-INF/MANIFEST.MF
@@ -52,4 +52,4 @@ Require-Bundle: org.eclipse.e4.core.di,
  org.eclipse.e4.core.services,
  org.eclipse.equinox.security;bundle-version="1.2.0",
  org.bbaw.bts.commons.fsaccess;bundle-version="1.0.0"
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.core.controller.impl/pom.xml
+++ b/org.bbaw.bts.core.controller.impl/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.controller.impl</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.controller.impl/pom.xml
+++ b/org.bbaw.bts.core.controller.impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.controller.impl</artifactId>

--- a/org.bbaw.bts.core.controller/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.controller/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Controller
 Bundle-SymbolicName: org.bbaw.bts.core.controller;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: BBAW
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.bbaw.bts.core.controller.dialogControllers,

--- a/org.bbaw.bts.core.controller/pom.xml
+++ b/org.bbaw.bts.core.controller/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.controller</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.controller/pom.xml
+++ b/org.bbaw.bts.core.controller/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.controller</artifactId>

--- a/org.bbaw.bts.core.corpus.controller.impl/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.corpus.controller.impl/META-INF/MANIFEST.MF
@@ -68,4 +68,4 @@ Require-Bundle: org.eclipse.e4.core.di,
  org.bbaw.bts.corpus.text.egy.egydsl.ui;bundle-version="1.0.0",
  org.eclipse.xtext.ui;bundle-version="2.4.4"
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.core.corpus.controller.impl/pom.xml
+++ b/org.bbaw.bts.core.corpus.controller.impl/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.corpus.controller.impl</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.corpus.controller.impl/pom.xml
+++ b/org.bbaw.bts.core.corpus.controller.impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.corpus.controller.impl</artifactId>

--- a/org.bbaw.bts.core.corpus.controller/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.corpus.controller/META-INF/MANIFEST.MF
@@ -21,4 +21,4 @@ Import-Package: org.bbaw.bts.btsmodel,
  org.eclipse.swt.graphics
 Require-Bundle: org.eclipse.jface.text;bundle-version="3.8.101",
  org.eclipse.xtext.ui
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.core.corpus.controller/pom.xml
+++ b/org.bbaw.bts.core.corpus.controller/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.corpus.controller</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.corpus.controller/pom.xml
+++ b/org.bbaw.bts.core.corpus.controller/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.corpus.controller</artifactId>

--- a/org.bbaw.bts.core.dao.corpus.couchDB/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.dao.corpus.couchDB/META-INF/MANIFEST.MF
@@ -25,5 +25,5 @@ Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.e4.core.contexts;bundle-version="1.3.1",
  org.eclipse.e4.core.di;bundle-version="1.3.0",
  javax.inject
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Export-Package: org.bbaw.bts.core.dao.corpus.couchdb

--- a/org.bbaw.bts.core.dao.corpus.couchDB/pom.xml
+++ b/org.bbaw.bts.core.dao.corpus.couchDB/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.dao.corpus.couchDB</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.dao.corpus.couchDB/pom.xml
+++ b/org.bbaw.bts.core.dao.corpus.couchDB/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.dao.corpus.couchDB</artifactId>

--- a/org.bbaw.bts.core.dao.corpus/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.dao.corpus/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CorpusDAO
 Bundle-SymbolicName: org.bbaw.bts.core.dao.corpus;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Activator: org.bbaw.bts.core.dao.corpus.internal.Activator
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/*.xml

--- a/org.bbaw.bts.core.dao.corpus/pom.xml
+++ b/org.bbaw.bts.core.dao.corpus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.dao.corpus</artifactId>

--- a/org.bbaw.bts.core.dao.corpus/pom.xml
+++ b/org.bbaw.bts.core.dao.corpus/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.dao.corpus</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.dao.couchDB/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.dao.couchDB/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: DaoCouchDB
 Bundle-SymbolicName: org.bbaw.bts.core.dao.couchDB;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: BBAW
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.bbaw.bts.core.dao,

--- a/org.bbaw.bts.core.dao.couchDB/pom.xml
+++ b/org.bbaw.bts.core.dao.couchDB/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.dao.couchDB</artifactId>

--- a/org.bbaw.bts.core.dao.couchDB/pom.xml
+++ b/org.bbaw.bts.core.dao.couchDB/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.dao.couchDB</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.dao/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.dao/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Dao
 Bundle-SymbolicName: org.bbaw.bts.core.dao;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: BBAW
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/*.xml

--- a/org.bbaw.bts.core.dao/pom.xml
+++ b/org.bbaw.bts.core.dao/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.dao</artifactId>

--- a/org.bbaw.bts.core.dao/pom.xml
+++ b/org.bbaw.bts.core.dao/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.dao</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.remote.dao.couchDB/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.remote.dao.couchDB/META-INF/MANIFEST.MF
@@ -35,4 +35,4 @@ Import-Package: com.google.gson;version="2.1.0",
 Export-Package: org.bbaw.bts.core.remote.dao.couchDB
 Bundle-ClassPath: .
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.core.remote.dao.couchDB/pom.xml
+++ b/org.bbaw.bts.core.remote.dao.couchDB/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.remote.dao.couchDB</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.remote.dao.couchDB/pom.xml
+++ b/org.bbaw.bts.core.remote.dao.couchDB/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.remote.dao.couchDB</artifactId>

--- a/org.bbaw.bts.core.remote.dao/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.remote.dao/META-INF/MANIFEST.MF
@@ -20,4 +20,4 @@ Import-Package: javax.inject,
  org.eclipse.e4.core.services.log,
  org.eclipse.e4.ui.model.application,
  org.eclipse.e4.ui.model.application.ui
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.core.remote.dao/pom.xml
+++ b/org.bbaw.bts.core.remote.dao/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.remote.dao</artifactId>

--- a/org.bbaw.bts.core.remote.dao/pom.xml
+++ b/org.bbaw.bts.core.remote.dao/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.remote.dao</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.services.corpus.impl/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.services.corpus.impl/META-INF/MANIFEST.MF
@@ -42,4 +42,4 @@ Require-Bundle: org.bbaw.bts.commons.libs.elasticsearch;bundle-version="1.0.0",
  org.eclipse.emf.ecore;bundle-version="2.10.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: BBAW
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.core.services.corpus.impl/pom.xml
+++ b/org.bbaw.bts.core.services.corpus.impl/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.services.corpus.impl</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.services.corpus.impl/pom.xml
+++ b/org.bbaw.bts.core.services.corpus.impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.services.corpus.impl</artifactId>

--- a/org.bbaw.bts.core.services.corpus/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.services.corpus/META-INF/MANIFEST.MF
@@ -12,4 +12,4 @@ Import-Package: org.bbaw.bts.core.commons.filter,
  org.eclipse.core.runtime;version="3.4.0"
 Export-Package: org.bbaw.bts.core.services.corpus
 Require-Bundle: org.bbaw.bts.commons.libs.elasticsearch;bundle-version="1.0.0"
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.core.services.corpus/pom.xml
+++ b/org.bbaw.bts.core.services.corpus/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.services.corpus</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.services.corpus/pom.xml
+++ b/org.bbaw.bts.core.services.corpus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.services.corpus</artifactId>

--- a/org.bbaw.bts.core.services.impl/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.services.impl/META-INF/MANIFEST.MF
@@ -40,4 +40,4 @@ Import-Package: javax.inject,
 Bundle-ActivationPolicy: lazy
 Export-Package: org.bbaw.bts.core.services.impl,
  org.bbaw.bts.core.services.impl.generic
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.core.services.impl/pom.xml
+++ b/org.bbaw.bts.core.services.impl/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.services.impl</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.services.impl/pom.xml
+++ b/org.bbaw.bts.core.services.impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.services.impl</artifactId>

--- a/org.bbaw.bts.core.services/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.services/META-INF/MANIFEST.MF
@@ -24,4 +24,4 @@ Require-Bundle: org.bbaw.bts.model;bundle-version="0.1.0",
  org.eclipse.equinox.ds;bundle-version="1.4.100",
  org.eclipse.osgi.services;bundle-version="3.3.100"
 Export-Package: org.bbaw.bts.core.services
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.core.services/pom.xml
+++ b/org.bbaw.bts.core.services/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.services</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.core.services/pom.xml
+++ b/org.bbaw.bts.core.services/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.core.services</artifactId>

--- a/org.bbaw.bts.core/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core/META-INF/MANIFEST.MF
@@ -2,6 +2,6 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Core
 Bundle-SymbolicName: org.bbaw.bts.core
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: BBAW
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7

--- a/org.bbaw.bts.corpus.egy.feature/pom.xml
+++ b/org.bbaw.bts.corpus.egy.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.corpus.egy.feature</artifactId>

--- a/org.bbaw.bts.corpus.text.egy.egydsl.tests/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.corpus.text.egy.egydsl.tests/META-INF/MANIFEST.MF
@@ -20,4 +20,4 @@ Import-Package: org.apache.log4j,
  org.hamcrest.core
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
 Export-Package: org.bbaw.bts.corpus.text.egy
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.corpus.text.egy.egydsl.ui/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.corpus.text.egy.egydsl.ui/META-INF/MANIFEST.MF
@@ -32,4 +32,4 @@ Export-Package: org.bbaw.bts.corpus.text.egy.ui,
  org.bbaw.bts.corpus.text.egy.ui.internal,
  org.bbaw.bts.corpus.text.egy.ui.quickfix
 Bundle-Activator: org.bbaw.bts.corpus.text.egy.ui.internal.EgyDslActivator
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.corpus.text.egy.egydsl.ui/pom.xml
+++ b/org.bbaw.bts.corpus.text.egy.egydsl.ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.corpus.text.egy.egydsl.ui</artifactId>

--- a/org.bbaw.bts.corpus.text.egy.egydsl.ui/pom.xml
+++ b/org.bbaw.bts.corpus.text.egy.egydsl.ui/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.corpus.text.egy.egydsl.ui</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.corpus.text.egy.egydsl/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.corpus.text.egy.egydsl/META-INF/MANIFEST.MF
@@ -34,4 +34,4 @@ Export-Package: org.bbaw.bts.corpus.text.egy,
  org.bbaw.bts.corpus.text.egy.scoping,
  org.bbaw.bts.corpus.text.egy.generator,
  org.bbaw.bts.corpus.text.egy.formatting
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.corpus.text.egy.egydsl/pom.xml
+++ b/org.bbaw.bts.corpus.text.egy.egydsl/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.corpus.text.egy.egydsl</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.corpus.text.egy.egydsl/pom.xml
+++ b/org.bbaw.bts.corpus.text.egy.egydsl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.corpus.text.egy.egydsl</artifactId>

--- a/org.bbaw.bts.db.couchdb.mac/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.db.couchdb.mac/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: BTS DB Mac
 Bundle-SymbolicName: org.bbaw.bts.db.couchdb.mac
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Fragment-Host: org.bbaw.bts.db.couchdb;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Eclipse-PlatformFilter: (& (osgi.os=macosx) (osgi.ws=cocoa) (osgi.arch=x86_64) )

--- a/org.bbaw.bts.db.couchdb.win32/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.db.couchdb.win32/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CouchDBWin32
 Bundle-SymbolicName: org.bbaw.bts.db.couchdb.win32
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Fragment-Host: org.bbaw.bts.db.couchdb;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=x86))

--- a/org.bbaw.bts.db.couchdb.win64/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.db.couchdb.win64/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CouchdbWin64
 Bundle-SymbolicName: org.bbaw.bts.db.couchdb.win64
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Fragment-Host: org.bbaw.bts.db.couchdb;bundle-version="1.0.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Eclipse-PlatformFilter: (& (osgi.ws=win32) (osgi.os=win32) (osgi.arch=x86_64))

--- a/org.bbaw.bts.db.couchdb/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.db.couchdb/META-INF/MANIFEST.MF
@@ -27,4 +27,4 @@ Import-Package: com.google.gson,
  org.eclipse.equinox.security.storage;version="1.0.0",
  org.lightcouch
 Bundle-ClassPath: .
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.db.couchdb/pom.xml
+++ b/org.bbaw.bts.db.couchdb/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.db.couchdb</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.db.couchdb/pom.xml
+++ b/org.bbaw.bts.db.couchdb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.db.couchdb</artifactId>

--- a/org.bbaw.bts.db/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.db/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Db
 Bundle-SymbolicName: org.bbaw.bts.db
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: BBAW
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.bbaw.bts.db

--- a/org.bbaw.bts.db/pom.xml
+++ b/org.bbaw.bts.db/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.db</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.db/pom.xml
+++ b/org.bbaw.bts.db/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.db</artifactId>

--- a/org.bbaw.bts.e4.p2/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.e4.p2/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: P2
 Bundle-SymbolicName: org.bbaw.bts.e4.p2
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: BBAW
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.eclipse.core.runtime,

--- a/org.bbaw.bts.model.corpus.edit/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.model.corpus.edit/META-INF/MANIFEST.MF
@@ -26,4 +26,4 @@ Import-Package: org.bbaw.bts.commons,
  org.eclipse.jface.viewers,
  org.eclipse.swt.graphics,
  org.eclipse.swt.widgets
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.model.corpus.edit/pom.xml
+++ b/org.bbaw.bts.model.corpus.edit/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.model.corpus.edit</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.model.corpus.edit/pom.xml
+++ b/org.bbaw.bts.model.corpus.edit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.model.corpus.edit</artifactId>

--- a/org.bbaw.bts.model.corpus/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.model.corpus/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.bbaw.bts.model.corpus;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.bbaw.bts.model.corpus/pom.xml
+++ b/org.bbaw.bts.model.corpus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.model.corpus</artifactId>

--- a/org.bbaw.bts.model.corpus/pom.xml
+++ b/org.bbaw.bts.model.corpus/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.model.corpus</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.model.edit/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.model.edit/META-INF/MANIFEST.MF
@@ -27,4 +27,4 @@ Import-Package: javax.inject,
  org.bbaw.bts.ui.resources,
  org.eclipse.swt.graphics,
  org.eclipse.swt.widgets
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.model.edit/pom.xml
+++ b/org.bbaw.bts.model.edit/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.model.edit</artifactId>

--- a/org.bbaw.bts.model.edit/pom.xml
+++ b/org.bbaw.bts.model.edit/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.model.edit</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.model.editor/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.model.editor/META-INF/MANIFEST.MF
@@ -15,4 +15,4 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.emf.edit.ui;visibility:=reexport,
  org.eclipse.ui.ide;visibility:=reexport
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.model.editor/pom.xml
+++ b/org.bbaw.bts.model.editor/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.model.editor</artifactId>

--- a/org.bbaw.bts.model.editor/pom.xml
+++ b/org.bbaw.bts.model.editor/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.model.editor</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.model/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.model/META-INF/MANIFEST.MF
@@ -22,4 +22,4 @@ Import-Package: com.google.gson,
  org.bbaw.bts.commons,
  org.eclipse.emf.ecore.xmi.impl,
  org.eclipselabs.emfjson
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.model/pom.xml
+++ b/org.bbaw.bts.model/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.model</artifactId>

--- a/org.bbaw.bts.model/pom.xml
+++ b/org.bbaw.bts.model/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.model</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.ui.commons.corpus/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.ui.commons.corpus/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: UICommonsCorpus
 Bundle-SymbolicName: org.bbaw.bts.ui.commons.corpus
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.bbaw.bts.ui.commons.corpus.converter,
  org.bbaw.bts.ui.commons.corpus.events,

--- a/org.bbaw.bts.ui.commons.corpus/pom.xml
+++ b/org.bbaw.bts.ui.commons.corpus/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.commons.corpus</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.ui.commons.corpus/pom.xml
+++ b/org.bbaw.bts.ui.commons.corpus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.commons.corpus</artifactId>

--- a/org.bbaw.bts.ui.commons/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.ui.commons/META-INF/MANIFEST.MF
@@ -70,4 +70,4 @@ Import-Package: javax.inject,
  org.eclipse.xtext.ui.editor.validation,
  org.eclipse.xtext.validation
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.ui.commons/pom.xml
+++ b/org.bbaw.bts.ui.commons/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.commons</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.ui.commons/pom.xml
+++ b/org.bbaw.bts.ui.commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.commons</artifactId>

--- a/org.bbaw.bts.ui.corpus.egy.commons/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.ui.corpus.egy.commons/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: UI Corpus Egy Commons
 Bundle-SymbolicName: org.bbaw.bts.ui.corpus.egy.commons
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: BTS
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: jseshlibs/bcmail-jdk14-138.jar,

--- a/org.bbaw.bts.ui.corpus.egy.commons/pom.xml
+++ b/org.bbaw.bts.ui.corpus.egy.commons/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.corpus.egy.commons</artifactId>

--- a/org.bbaw.bts.ui.corpus.egy.commons/pom.xml
+++ b/org.bbaw.bts.ui.corpus.egy.commons/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.corpus.egy.commons</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.ui.corpus.egy/pom.xml
+++ b/org.bbaw.bts.ui.corpus.egy/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.corpus.egy</artifactId>

--- a/org.bbaw.bts.ui.corpus/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.ui.corpus/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: CorpusUI
 Bundle-SymbolicName: org.bbaw.bts.ui.corpus;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Activator: org.bbaw.bts.ui.corpus.internal.Activator
 Bundle-Vendor: BBAW
 Export-Package: org.bbaw.bts.ui.corpus.dialogs,

--- a/org.bbaw.bts.ui.corpus/pom.xml
+++ b/org.bbaw.bts.ui.corpus/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.corpus</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.ui.corpus/pom.xml
+++ b/org.bbaw.bts.ui.corpus/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.corpus</artifactId>

--- a/org.bbaw.bts.ui.font.academy/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.ui.font.academy/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: AcademyFont
 Bundle-SymbolicName: org.bbaw.bts.ui.font.academy;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: BBAW
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Import-Package: org.bbaw.bts.ui.font

--- a/org.bbaw.bts.ui.font.academy/pom.xml
+++ b/org.bbaw.bts.ui.font.academy/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.font.academy</artifactId>

--- a/org.bbaw.bts.ui.font.academy/pom.xml
+++ b/org.bbaw.bts.ui.font.academy/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.font.academy</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.ui.font.egyFont/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.ui.font.egyFont/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: EgyFont
 Bundle-SymbolicName: org.bbaw.bts.ui.font.egyFont;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: BBAW
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.bbaw.bts.ui.font,

--- a/org.bbaw.bts.ui.font/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.ui.font/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Font
 Bundle-SymbolicName: org.bbaw.bts.ui.font;singleton:=true
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: BBAW
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/*.xml

--- a/org.bbaw.bts.ui.font/pom.xml
+++ b/org.bbaw.bts.ui.font/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.font</artifactId>

--- a/org.bbaw.bts.ui.font/pom.xml
+++ b/org.bbaw.bts.ui.font/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.font</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.ui.main/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.ui.main/META-INF/MANIFEST.MF
@@ -78,4 +78,4 @@ Import-Package: com.opcoach.e4.preferences,
  org.elasticsearch.index.query,
  org.osgi.service.event;version="1.3.0"
 Bundle-ActivationPolicy: lazy
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier

--- a/org.bbaw.bts.ui.main/pom.xml
+++ b/org.bbaw.bts.ui.main/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.main</artifactId>

--- a/org.bbaw.bts.ui.main/pom.xml
+++ b/org.bbaw.bts.ui.main/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.main</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.ui.resources.impl/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.ui.resources.impl/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: UI Resource Impl
 Bundle-SymbolicName: org.bbaw.bts.ui.resources.impl
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: BBAW
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/resourceprovider.xml

--- a/org.bbaw.bts.ui.resources.impl/pom.xml
+++ b/org.bbaw.bts.ui.resources.impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.resources.impl</artifactId>

--- a/org.bbaw.bts.ui.resources.impl/pom.xml
+++ b/org.bbaw.bts.ui.resources.impl/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.resources.impl</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.ui.resources/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.ui.resources/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: UIResources
 Bundle-SymbolicName: org.bbaw.bts.ui.resources
-Bundle-Version: 3.1.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Vendor: BBAW
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Require-Bundle: org.eclipse.swt;bundle-version="3.7.0",

--- a/org.bbaw.bts.ui.resources/pom.xml
+++ b/org.bbaw.bts.ui.resources/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.resources</artifactId>
-  <version>3.1.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.bbaw.bts.ui.resources/pom.xml
+++ b/org.bbaw.bts.ui.resources/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.ui.resources</artifactId>

--- a/org.eclipse.e4.ui.workbench.perspectiveswitcher/pom.xml
+++ b/org.eclipse.e4.ui.workbench.perspectiveswitcher/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.eclipse.e4.ui.workbench.perspectiveswitcher</artifactId>

--- a/org.eclipselabs.emfjson.couchdb.feature/pom.xml
+++ b/org.eclipselabs.emfjson.couchdb.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <artifactId>org.bbaw.bts.eclipselabs.emfjson.couchdb.feature</artifactId>
   <version>0.4.0-SNAPSHOT</version>

--- a/org.eclipselabs.emfjson.couchdb.ui/pom.xml
+++ b/org.eclipselabs.emfjson.couchdb.ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.eclipselabs.emfjson.couchdb.ui</artifactId>

--- a/org.eclipselabs.emfjson.couchdb/pom.xml
+++ b/org.eclipselabs.emfjson.couchdb/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.bbaw.bts.eclipselabs.emfjson.couchdb</artifactId>

--- a/org.eclipselabs.emfjson.feature/pom.xml
+++ b/org.eclipselabs.emfjson.feature/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <artifactId>org.bbaw.bts.eclipselabs.emfjson.feature</artifactId>
   <version>0.4.0-SNAPSHOT</version>

--- a/org.eclipselabs.emfjson/pom.xml
+++ b/org.eclipselabs.emfjson/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <artifactId>org.bbaw.bts.eclipselabs.emfjson</artifactId>
   <version>0.6.1-SNAPSHOT</version>

--- a/org.fuberlin.bts.ui.corpus.egy.annotations/META-INF/MANIFEST.MF
+++ b/org.fuberlin.bts.ui.corpus.egy.annotations/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Annotations
 Bundle-SymbolicName: org.fuberlin.bts.ui.corpus.egy.annotations;singleton:=true
-Bundle-Version: 1.0.0.qualifier
+Bundle-Version: 3.1.1.qualifier
 Bundle-Activator: org.fuberlin.bts.ui.corpus.egy.annotations.internal.Activator
 Bundle-Vendor: CPlutte
 Require-Bundle: javax.inject,

--- a/org.fuberlin.bts.ui.corpus.egy.annotations/pom.xml
+++ b/org.fuberlin.bts.ui.corpus.egy.annotations/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.fuberlin.bts.ui.corpus.egy.annotations</artifactId>

--- a/org.fuberlin.bts.ui.corpus.egy.annotations/pom.xml
+++ b/org.fuberlin.bts.ui.corpus.egy.annotations/pom.xml
@@ -9,6 +9,6 @@
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.fuberlin.bts.ui.corpus.egy.annotations</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>3.1.1-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>

--- a/org.lightcouch/pom.xml
+++ b/org.lightcouch/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.lightcouch</artifactId>

--- a/org.ramo.klevis.p2.core.service/pom.xml
+++ b/org.ramo.klevis.p2.core.service/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.bbaw.bts</groupId>
     <artifactId>aaew-bts</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
   </parent>
   <groupId>org.bbaw.bts</groupId>
   <artifactId>org.ramo.klevis.p2.core.service</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.bbaw.bts</groupId>
 	<artifactId>aaew-bts</artifactId>
-	<version>3.1.0</version>
+	<version>3.1.1</version>
 	<packaging>pom</packaging>
 
 	<modules>
@@ -67,7 +67,7 @@
 	</modules>
 
 	<properties>
-		<tycho.version>0.19.0</tycho.version>
+		<tycho.version>1.0.0</tycho.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 	</properties>
@@ -101,7 +101,7 @@
 				<executions>
 					<execution>
 						<id>versions</id>
-						<phase>clean</phase>
+						<phase>package</phase>
 						<goals>
 							<goal>update-pom</goal>
 						</goals>
@@ -117,6 +117,7 @@
 			<plugin>
 				<groupId>org.eclipse.tycho</groupId>
 				<artifactId>target-platform-configuration</artifactId>
+				<version>${tycho.version}</version>
 				<configuration>
 					<environments>
 						<!--

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 	</modules>
 
 	<properties>
-		<tycho.version>1.0.0</tycho.version>
+		<tycho.version>0.19.0</tycho.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
 	</properties>
@@ -101,7 +101,7 @@
 				<executions>
 					<execution>
 						<id>versions</id>
-						<phase>package</phase>
+						<phase>clean</phase>
 						<goals>
 							<goal>update-pom</goal>
 						</goals>


### PR DESCRIPTION
As it turns out, upgrade from tycho `0.19.0` to tycho `1.0.0` ends in desaster so we stick with former. Make use of both goals `update-pom` and `set-version` of `tycho-versions` plugin (after manual update of bundle versions in `MANIFEST.MF` files tho).

    mvn clean
    `mvn tycho-versions:set-version -DnewVersion=3.1.1`

