### PR TITLE
Prevent huge load on local database for privilege evaluation.

### DIFF
--- a/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/BTSUserControllerImpl.java
+++ b/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/BTSUserControllerImpl.java
@@ -1,7 +1,9 @@
 package org.bbaw.bts.core.controller.impl.generalController;
 
 import java.io.FileNotFoundException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import javax.inject.Inject;
@@ -52,6 +54,8 @@ public class BTSUserControllerImpl implements BTSUserController {
 	@Inject
 	private IEclipseContext context;
 
+	// user object cache
+	private Map<String, BTSUser> userCache;
 
 	@Inject
 	public BTSUserControllerImpl(IEclipseContext ctx) {
@@ -67,8 +71,20 @@ public class BTSUserControllerImpl implements BTSUserController {
 
 	@Override
 	public String getUserDisplayName(String userId) {
-		return userService.getDisplayName(userId, null);
-		
+		BTSUser user = getUser(userId);
+		return (user != null) ? user.getName() : userId;
+	}
+
+	private BTSUser getUser(String userId) {
+		if (userCache == null) {
+			userCache = new HashMap<String, BTSUser>();
+		}
+		BTSUser user = userCache.getOrDefault(userId, null);
+		if (user == null) {
+			user = userService.find(userId, null);
+			userCache.put(userId, user);
+		}
+		return user;
 	}
 
 	@Override

--- a/org.bbaw.bts.core.dao.couchDB/src/org/bbaw/bts/dao/couchDB/CouchDBDao.java
+++ b/org.bbaw.bts.core.dao.couchDB/src/org/bbaw/bts/dao/couchDB/CouchDBDao.java
@@ -366,6 +366,7 @@ public abstract class CouchDBDao<E extends BTSDBBaseObject, K extends Serializab
 	@SuppressWarnings("unchecked")
 	@Override
 	public E find(K key, String path, String revision)
+	// XXX apparently not used at all ever
 	{
 		CouchDbClient dbClient = connectionProvider.getDBClient(
 				CouchDbClient.class, path);

--- a/org.bbaw.bts.core.services.impl/src/org/bbaw/bts/core/services/impl/generic/GenericObjectServiceImpl.java
+++ b/org.bbaw.bts.core.services.impl/src/org/bbaw/bts/core/services/impl/generic/GenericObjectServiceImpl.java
@@ -314,17 +314,17 @@ public abstract class GenericObjectServiceImpl<E extends BTSDBBaseObject, K exte
 	}
 	
 	
-	public String getDisplayName(String userId, IProgressMonitor monitor)
+	public String getDisplayName(String objectId, IProgressMonitor monitor)
 	{
 		BTSObject o = null;
 		try {
-			o = (BTSObject) find((K) userId, monitor);
+			o = (BTSObject) find((K) objectId, monitor);
 		} catch (Exception e) {
 		}
 		if (o != null) {
 			return o.getName();
 		}
-		return userId;
+		return objectId;
 		
 	}
 	protected String[] getActiveProjects() {

--- a/org.bbaw.bts.core.services.impl/src/org/bbaw/bts/core/services/impl/services/BTSEvaluationServiceImpl.java
+++ b/org.bbaw.bts.core.services.impl/src/org/bbaw/bts/core/services/impl/services/BTSEvaluationServiceImpl.java
@@ -78,7 +78,10 @@ public class BTSEvaluationServiceImpl implements BTSEvaluationService
 	@Named(BTSCoreConstants.USERGROUPS_OF_AUTHENTICATED_USER)
 	private List<BTSUserGroup> userGroups;
 
+	// registries for faster lookup	
 	private Map<String, BTSProjectDBCollection> dbCollectionCache;
+
+	private Map<String, BTSUserGroup> userGroupCache;
 
 	private BTSProjectService projectService;
 
@@ -345,6 +348,22 @@ public class BTSEvaluationServiceImpl implements BTSEvaluationService
 		}
 	}
 
+	private BTSUserGroup findUserGroupInCacheOrElse(String usergroupId) {
+		if (userGroupCache == null) {
+			userGroupCache = new HashMap<>();
+		}
+		BTSUserGroup userGroup = userGroupCache.getOrDefault(usergroupId, null);
+		if (userGroup == null) {
+			try {
+				userGroup = userGroupService.find(usergroupId, null);
+				userGroupCache.put(usergroupId, userGroup);
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+		return userGroup;
+	}
+
 	private boolean userIsReader(BTSDBBaseObject object) {
 		if (object == null) return false;
 		
@@ -399,7 +418,7 @@ public class BTSEvaluationServiceImpl implements BTSEvaluationService
 			for (String id : user.getGroupIds()) {
 				BTSUserGroup g = null;
 				try {
-					g = userGroupService.find(id, null);
+					g = findUserGroupInCacheOrElse(id);
 				} catch (Exception e) {
 					e.printStackTrace();
 				}

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/handlers/AddNewTCObjectHandler.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/handlers/AddNewTCObjectHandler.java
@@ -3,7 +3,6 @@ package org.bbaw.bts.ui.corpus.handlers;
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.bbaw.bts.btsmodel.BTSObject;
 import org.bbaw.bts.core.controller.generalController.PermissionsAndExpressionsEvaluationController;
 import org.bbaw.bts.core.corpus.controller.partController.CorpusNavigatorController;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSAnnotation;
@@ -26,11 +25,15 @@ public class AddNewTCObjectHandler
 	@Inject
 	private CorpusNavigatorController navigatorController;
 
+	private BTSCorpusObject latestSelection = null;
+	private boolean latestStatus = false;
+
 	@Execute
 	public void execute(@Named(IServiceConstants.ACTIVE_SELECTION) @Optional BTSCorpusObject selection,
 			@Named(IServiceConstants.ACTIVE_SHELL) final Shell shell, EventBroker eventBroker,
 			CorpusNavigatorController corpusNavigatorController)
 	{
+		latestSelection = selection;
 		final BTSTCObject object = corpusNavigatorController.createNewTCObject(selection);
 		corpusNavigatorController.save(object);
 		eventBroker.post("model_new/BTSTCObject", object);
@@ -38,11 +41,14 @@ public class AddNewTCObjectHandler
 
 	@CanExecute
 	public boolean canExecute(
-			@Named(IServiceConstants.ACTIVE_SELECTION) @Optional BTSObject selection) {
-		if (selection instanceof BTSCorpusObject && !(selection instanceof BTSAnnotation)) {
-			String dbCollectionName = navigatorController.getDBCollectionName(
-					(BTSCorpusObject)selection);
-			return permissionController.authenticatedUserMayAddToDBCollection(dbCollectionName);
+			@Named(IServiceConstants.ACTIVE_SELECTION) @Optional BTSCorpusObject selection) {
+		if (!(selection instanceof BTSAnnotation)) {
+			if ((latestSelection == null) || !selection.get_id().equals(latestSelection.get_id())) {
+				String dbCollectionName = navigatorController.getDBCollectionName(selection);
+				latestStatus = permissionController.authenticatedUserMayAddToDBCollection(dbCollectionName);
+				latestSelection = selection;
+			}
+			return latestStatus;
 		}
 		return false;
 	}

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/handlers/MoveObjectAmongProjectDBCollectionHandler.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/handlers/MoveObjectAmongProjectDBCollectionHandler.java
@@ -19,9 +19,14 @@ import org.eclipse.e4.core.di.annotations.Execute;
 import org.eclipse.e4.core.di.annotations.CanExecute;
 import org.eclipse.e4.core.di.annotations.Optional;
 import org.eclipse.e4.ui.services.IServiceConstants;
+import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.swt.widgets.Shell;
 
 public class MoveObjectAmongProjectDBCollectionHandler {
+
+	private BTSObject latestSelection = null;
+	private boolean latestStatus = false;
+
 	@Execute
 	public void execute(@Optional @Named(IServiceConstants.ACTIVE_SELECTION) BTSDBBaseObject selection,
 			@Named(IServiceConstants.ACTIVE_SHELL) final Shell shell,
@@ -48,10 +53,10 @@ public class MoveObjectAmongProjectDBCollectionHandler {
 			MoveObjectAmongProjectDBCollectionSelectionDialog dialog = new MoveObjectAmongProjectDBCollectionSelectionDialog(shell, 
 					rootNode, moveDBCollectionFilter, selection, currentProject);
 			dialog.create();
-			
+
 			ContextInjectionFactory.inject(dialog, context);
-			
-			if (dialog.open() == dialog.OK)
+
+			if (dialog.open() == Dialog.OK)
 			{
 				// get selection result
 				targetDBCollectionPath = dialog.getTargetDBCollectionPath();
@@ -69,13 +74,13 @@ public class MoveObjectAmongProjectDBCollectionHandler {
 	
 	
 	@CanExecute
-	public boolean canExecute(@Optional @Named(IServiceConstants.ACTIVE_SELECTION) BTSDBBaseObject selection,
-			PermissionsAndExpressionsEvaluationController evaluationController) {
-		if (selection instanceof BTSObject)
-		{
-			return evaluationController.authenticatedUserMayEditObject((BTSObject) selection);
+	public boolean canExecute(@Optional @Named(IServiceConstants.ACTIVE_SELECTION) BTSObject selection,
+			PermissionsAndExpressionsEvaluationController permissionController) {
+		if ((latestSelection == null) || !selection.get_id().equals(latestSelection.get_id())) {
+			latestStatus = permissionController.authenticatedUserMayEditObject(selection);
+			latestSelection = selection;
 		}
-		return false;
+		return latestStatus;
 	}
 		
 }


### PR DESCRIPTION
### Description

When determining user privileges on current object selections, a large number of requests is repeatedly issued towards the local database because user and user group objects get queried and deserialized over and over. With additional calls of privilege evaluation methods for determination of application UI model command availability (a9f028a etc), this becomes a huge problem. 

#### Related issues

  * [#9086](https://redmine.bbaw.de/issues/9086)
  * #107 

### Proposed Fix

Prevent heavy load on local database during user privilege computation by makeshift object caching. Reuse objects previously retrieved from database.

**problem tho**: these objects might be subject to change. These changes need to be detected by classes that use caches, like `BTSUserControllerImpl`.

Anyway this is supposed to fix #107 

#### most significant commits for merge
 * 5e88cec31fc3cc11761a4e483062490d68cf77be
 * aa56505fba83a308e4f10572047fcf06a89719c1