### PR TITLE
Fix Heap Overflow during Passport Editor Content Assist

### DIFF
--- a/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/GeneralBTSObjectControllerImpl.java
+++ b/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/GeneralBTSObjectControllerImpl.java
@@ -91,24 +91,7 @@ public class GeneralBTSObjectControllerImpl implements
 //							.query(query, BTSConstants.OBJECT_STATE_ACTIVE,
 //									false));
 					corpus = true;
-				} else if (!corpus) {
-					
-					BTSQueryRequest query = new BTSQueryRequest();
-					QueryBuilder qb = QueryBuilders.prefixQuery("name", text);
-
-					SearchRequestBuilder sqb = projectService
-							.getSearchRequestBuilder();
-					sqb.setQuery(qb);
-
-					list.addAll(queryObjects(query, BTSConstants.OBJECT_STATE_ACTIVE,
-							false, "BTSCorpusObject", monitor));
-					
-//					list.addAll((Collection<? extends BTSObject>) corpusObjectService
-//							.query(query, BTSConstants.OBJECT_STATE_ACTIVE,
-//									false));
-					corpus = true;
-				
-			}
+				}
 		}
 
 		return list;

--- a/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/GeneralBTSObjectControllerImpl.java
+++ b/org.bbaw.bts.core.controller.impl/src/org/bbaw/bts/core/controller/impl/generalController/GeneralBTSObjectControllerImpl.java
@@ -25,6 +25,8 @@ import org.elasticsearch.index.query.QueryBuilders;
 public class GeneralBTSObjectControllerImpl implements
 		GeneralBTSObjectController {
 
+    private static final int MAX_PROPOSALS = 50;
+
 	@Inject
 	private BTSConfigurationController configurationController;
 	
@@ -40,6 +42,7 @@ public class GeneralBTSObjectControllerImpl implements
 			.must(QueryBuilders.matchPhrasePrefixQuery("name", text)));
 		// try and lookup objects by id first
 		query.setIdQuery(true);
+        query.setSize(MAX_PROPOSALS);
 		List<BTSObject> result = queryObjects(query, BTSConstants.OBJECT_STATE_ACTIVE,
 				false, className, monitor);
 		if (result != null && !result.isEmpty()) {
@@ -64,34 +67,15 @@ public class GeneralBTSObjectControllerImpl implements
 		//FIXME aktualisieren und auf map umstellen
 
 		if (configItem != null && !configItem.getOwnerTypesMap().isEmpty()) {
-			boolean corpus = false;
+            if (configurationController.objectMayReferenceToThs(object, configItem))
+                list.addAll(getTypedObjectProposalsFor(text, "BTSThsEntry", monitor));
 
-				if (configurationController.objectMayReferenceToThs(object, configItem)) {
-					list.addAll(getTypedObjectProposalsFor(text, "BTSThsEntry", monitor));
-				}
-				if (configurationController.objectMayReferenceToWList(object, configItem)) {
-					list.addAll(getTypedObjectProposalsFor(text, "BTSLemmaEntry", monitor));
 
-				} else if (configurationController.objectMayReferenceToCorpus(object, configItem)) {
-					BTSQueryRequest query = new BTSQueryRequest();
-					QueryBuilder qb = QueryBuilders.prefixQuery("name", text);
+            if (configurationController.objectMayReferenceToWList(object, configItem))
+                list.addAll(getTypedObjectProposalsFor(text, "BTSLemmaEntry", monitor));
 
-					SearchRequestBuilder sqb = projectService
-							.getSearchRequestBuilder();
-					sqb.setQuery(qb);
-					List<FilterBuilder> filters = makeFilterList(configItem, object);
-
-					FilterBuilder[] filterArray = filters
-							.toArray(new FilterBuilder[filters.size()]);
-					sqb.setPostFilter(FilterBuilders.orFilter(filterArray));
-					list.addAll(queryObjects(query, BTSConstants.OBJECT_STATE_ACTIVE,
-							false, "BTSCorpusObject", monitor));
-//					
-//					list.addAll((Collection<? extends BTSObject>) corpusObjectService
-//							.query(query, BTSConstants.OBJECT_STATE_ACTIVE,
-//									false));
-					corpus = true;
-				}
+            if (configurationController.objectMayReferenceToCorpus(object, configItem))
+                list.addAll(getTypedObjectProposalsFor(text, "BTSCorpusObject", monitor));
 		}
 
 		return list;
@@ -100,9 +84,7 @@ public class GeneralBTSObjectControllerImpl implements
 	@Override
 	public List<BTSObject> queryObjects(BTSQueryRequest query,
 			String objectState, boolean registerQuery, String className, IProgressMonitor monitor) {
-		return objectService.queryObjects(query,
-				objectState, registerQuery, className, monitor);
-		
+		return objectService.queryObjects(query, objectState, registerQuery, className, monitor);
 	}
 	
 

--- a/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/BTSTextEditorControllerImpl.java
+++ b/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/BTSTextEditorControllerImpl.java
@@ -27,12 +27,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.inject.Inject;
-import javax.naming.Context;
-
-import jsesh.mdc.MDCSyntaxError;
-import jsesh.mdcDisplayer.draw.MDCDrawingFacade;
-import jsesh.mdcDisplayer.preferences.DrawingSpecification;
-import jsesh.mdcDisplayer.preferences.DrawingSpecificationsImplementation;
 
 import org.bbaw.bts.btsmodel.BTSComment;
 import org.bbaw.bts.btsmodel.BTSIdentifiableItem;
@@ -61,10 +55,7 @@ import org.bbaw.bts.corpus.btsCorpusModel.BTSText;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSTextContent;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSTextItems;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSWord;
-import org.bbaw.bts.corpus.btsCorpusModel.BtsCorpusModelFactory;
 import org.bbaw.bts.corpus.btsCorpusModel.BtsCorpusModelPackage;
-import org.bbaw.bts.corpus.text.egy.EgyDslStandaloneSetup;
-import org.bbaw.bts.corpus.text.egy.egyDsl.TextContent;
 import org.bbaw.bts.corpus.text.egy.ui.internal.EgyDslActivator;
 import org.bbaw.bts.ui.commons.corpus.text.BTSAnnotationAnnotation;
 import org.bbaw.bts.ui.commons.corpus.text.BTSCommentAnnotation;
@@ -97,7 +88,6 @@ import org.eclipse.emf.edit.command.RemoveCommand;
 import org.eclipse.emf.edit.command.SetCommand;
 import org.eclipse.emf.edit.domain.EditingDomain;
 import org.eclipse.jface.text.Document;
-import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.IAnnotationModel;
@@ -106,14 +96,16 @@ import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.PaletteData;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.xtext.parser.IParseResult;
-import org.eclipse.xtext.parser.IParser;
 import org.eclipse.xtext.resource.XtextResource;
 import org.eclipse.xtext.resource.XtextResourceSet;
-import org.eclipse.xtext.util.StringInputStream;
 import org.elasticsearch.index.query.QueryBuilders;
 
 import com.google.inject.Injector;
+
+import jsesh.mdc.MDCSyntaxError;
+import jsesh.mdcDisplayer.draw.MDCDrawingFacade;
+import jsesh.mdcDisplayer.preferences.DrawingSpecification;
+import jsesh.mdcDisplayer.preferences.DrawingSpecificationsImplementation;
 
 public class BTSTextEditorControllerImpl implements BTSTextEditorController
 {

--- a/org.bbaw.bts.db.couchdb/src/org/bbaw/bts/db/couchdb/impl/CouchDBManager.java
+++ b/org.bbaw.bts.db.couchdb/src/org/bbaw/bts/db/couchdb/impl/CouchDBManager.java
@@ -1032,7 +1032,6 @@ public class CouchDBManager implements DBManager {
 					+ "\"bulk_size\": 100,\r\n"
 					+ "\"bulk_timeout\": \"500ms\"\r\n" + "}\r\n}";
 			// FIXME suppress credentials in logging
-			logger.info(json);
 			esClient2.index(
 					Requests.indexRequest("_river").type(collectionName)
 							.id("_meta").source(json)).actionGet();

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/passportEditor/PassportEntryItemEditor.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/passportEditor/PassportEntryItemEditor.java
@@ -8,11 +8,8 @@ import javax.inject.Named;
 
 import org.bbaw.bts.btsmodel.BTSConfigItem;
 import org.bbaw.bts.btsmodel.BTSObject;
-import org.bbaw.bts.btsmodel.BtsmodelFactory;
-import org.bbaw.bts.btsmodel.BtsmodelPackage;
 import org.bbaw.bts.commons.BTSConstants;
 import org.bbaw.bts.core.commons.BTSCoreConstants;
-import org.bbaw.bts.core.controller.generalController.BTSConfigurationController;
 import org.bbaw.bts.core.controller.generalController.GeneralBTSObjectController;
 import org.bbaw.bts.core.controller.generalController.PermissionsAndExpressionsEvaluationController;
 import org.bbaw.bts.core.corpus.controller.generalController.PassportConfigurationController;
@@ -64,6 +61,7 @@ import org.eclipse.jface.bindings.keys.KeyStroke;
 import org.eclipse.jface.bindings.keys.ParseException;
 import org.eclipse.jface.databinding.swt.WidgetProperties;
 import org.eclipse.jface.databinding.viewers.ViewersObservables;
+import org.eclipse.jface.dialogs.Dialog;
 import org.eclipse.jface.fieldassist.ContentProposalAdapter;
 import org.eclipse.jface.fieldassist.ControlDecoration;
 import org.eclipse.jface.fieldassist.FieldDecorationRegistry;
@@ -75,18 +73,14 @@ import org.eclipse.jface.viewers.ComboViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.FocusAdapter;
 import org.eclipse.swt.events.FocusEvent;
-import org.eclipse.swt.events.FocusListener;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
-import org.eclipse.swt.events.KeyListener;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.MouseAdapter;
 import org.eclipse.swt.events.MouseEvent;
-import org.eclipse.swt.events.MouseWheelListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
@@ -96,7 +90,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
-import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Text;
@@ -107,8 +100,6 @@ public class PassportEntryItemEditor extends PassportEntryEditorComposite {
 	private BTSConfigItem itemConfig;
 	@Inject
 	private IEclipseContext context;
-	@Inject
-	private BTSPassport passport;
 	@Inject
 	private EditingDomain editingDomain;
 	@Inject
@@ -327,6 +318,7 @@ public class PassportEntryItemEditor extends PassportEntryEditorComposite {
 		// }
 	}
 
+	@SuppressWarnings("restriction")
 	private void setButtonImage(Label button, BTSConfigItem ic, boolean isAdd) {
 		if (BTSCoreConstants.WIDGET_TYPE_TEXT.equals(ic
 				.getPassportEditorConfig()

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/passportEditor/PassportEntryItemEditor.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/passportEditor/PassportEntryItemEditor.java
@@ -612,28 +612,26 @@ public class PassportEntryItemEditor extends PassportEntryEditorComposite {
 		ths_select_text.addKeyListener(new KeyAdapter() {
 			@Override
 			public void keyReleased(KeyEvent e) {
-				if(e.keyCode == SWT.CR || e.keyCode == SWT.KEYPAD_CR){
+				// CTRL+F
+				if (((e.stateMask & SWT.CTRL) == SWT.CTRL) && (e.keyCode == 102)){
 					// open search dialog
 					IEclipseContext child = context.createChild("searchselect");
-
 					context.set(BTSConstants.OBJECT_TYPES_ARRAY, new String[]{BTSConstants.THS_ENTRY});
 					BTSObjectTypeSubtypeViewerFilter viewerFilter = passportConfigurationController.createObjectTypeSubtypeFilterByReferencedPath(corpusObject, itemConfig2);
 					context.set(BTSObjectTypeSubtypeViewerFilter.class, viewerFilter);
+
 					SearchSelectObjectDialog dialog = ContextInjectionFactory.make(
 							SearchSelectObjectDialog.class, child);
-					if (dialog.open() == dialog.OK) {
+					if (dialog.open() == Dialog.OK) {
 						BTSObject object = dialog.getObject();
-						System.out.println(object.get_id());
 						Command command = SetCommand.create(editingDomain,
 								entry, BtsCorpusModelPackage.eINSTANCE.getBTSPassportEntry_Value(),
 								object.get_id());
 						editingDomain.getCommandStack().execute(command);
 						ths_select_text.setText(object.getName());
 						ths_select_text.setData(object);
-
 					}
-			    } else if (e.keyCode == SWT.BS)
-			    {
+			    } else if (e.keyCode == SWT.BS) {
 			    	Command command = SetCommand.create(editingDomain,
 							entry, BtsCorpusModelPackage.eINSTANCE.getBTSPassportEntry_Value(),
 							null);

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/passportEditor/PassportEntryItemEditor.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/passportEditor/PassportEntryItemEditor.java
@@ -556,6 +556,18 @@ public class PassportEntryItemEditor extends PassportEntryEditorComposite {
 
 	}
 
+
+	private void linkContentassistResultToTextField(BTSPassportEntry entry) {
+		BTSObject object = null;
+		if (entry.getValue() != null) {
+			object = thsNavigatorController.find(entry.getValue(), null);
+			ths_select_text.setData(object);
+		}
+		if (object != null) {
+			ths_select_text.setText(object.getName());
+		}
+	}
+
 	private void loadSelectTHSWidget(final BTSConfigItem itemConfig2,
 			final BTSPassportEntry entry) {
 		Label label = new Label(this, SWT.NONE);
@@ -612,6 +624,9 @@ public class PassportEntryItemEditor extends PassportEntryEditorComposite {
 		
 		ths_select_text.addKeyListener(new KeyAdapter() {
 
+		linkContentassistResultToTextField(entry);
+
+		ths_select_text.addKeyListener(new KeyAdapter() {
 			@Override
 			public void keyReleased(KeyEvent e) {
 				if(e.keyCode == SWT.CR || e.keyCode == SWT.KEYPAD_CR){

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/passportEditor/PassportEntryItemEditor.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/passportEditor/PassportEntryItemEditor.java
@@ -580,49 +580,32 @@ public class PassportEntryItemEditor extends PassportEntryEditorComposite {
 		ths_select_text = new Text(this, SWT.BORDER | SWT.READ_ONLY);
 		ths_select_text.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false, 1, 1));
 		final char[] autoActivationCharacters = new char[] { '.', '#' };
-		ths_select_text.addFocusListener(new FocusAdapter() {
 
-			@Override
-			public void focusGained(FocusEvent e) {
-				if (PassportEntryItemEditor.this.userMayEdit)
-				{
-				try {
-					KeyStroke keyStroke = KeyStroke.getInstance("Ctrl+Space");
-					ContentProposalAdapter adapter = new ContentProposalAdapter(
-							ths_select_text, new TextContentAdapter(),
-							getObjectProposalProvider(itemConfig), keyStroke,
-							autoActivationCharacters);
-					adapter.setProposalAcceptanceStyle(ContentProposalAdapter.PROPOSAL_REPLACE);
-					adapter.addContentProposalListener(new IContentProposalListener() {
-
-						@Override
-						public void proposalAccepted(IContentProposal proposal) {
-							System.out.println(proposal);
-							Command command = SetCommand.create(
-									editingDomain,
-									entry, BtsCorpusModelPackage.eINSTANCE.getBTSPassportEntry_Value(),
-									proposal.getContent());
-							editingDomain.getCommandStack().execute(
-									command);
-							entry.setValue(proposal.getContent());
-						}
-					});
-				} catch (ParseException e1) {
-					e1.printStackTrace();
+		try {
+			ContentProposalAdapter adapter = new ContentProposalAdapter(
+					ths_select_text,
+					new TextContentAdapter(),
+					getObjectProposalProvider(itemConfig),
+					KeyStroke.getInstance("Ctrl+Space"),
+					autoActivationCharacters);
+			adapter.setProposalAcceptanceStyle(ContentProposalAdapter.PROPOSAL_REPLACE);
+			adapter.addContentProposalListener(new IContentProposalListener() {
+				@Override
+				public void proposalAccepted(IContentProposal proposal) {
+					Command command = SetCommand.create(
+							editingDomain,
+							entry,
+							BtsCorpusModelPackage.eINSTANCE.getBTSPassportEntry_Value(),
+							proposal.getContent());
+					editingDomain.getCommandStack().execute(
+							command);
+					entry.setValue(proposal.getContent());
+					linkContentassistResultToTextField(entry);
 				}
-				}
-			}
-		});
-		BTSObject object = null;
-		if (entry.getValue() != null) {
-			object = thsNavigatorController.find(entry.getValue(), null);
-			ths_select_text.setData(object);
+			});
+		} catch (ParseException e1) {
+			e1.printStackTrace();
 		}
-		if (object != null) {
-			ths_select_text.setText(object.getName());
-		}
-		
-		ths_select_text.addKeyListener(new KeyAdapter() {
 
 		linkContentassistResultToTextField(entry);
 

--- a/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/passportEditor/PassportEntryItemEditor.java
+++ b/org.bbaw.bts.ui.corpus/src/org/bbaw/bts/ui/corpus/parts/passportEditor/PassportEntryItemEditor.java
@@ -666,44 +666,37 @@ public class PassportEntryItemEditor extends PassportEntryEditorComposite {
 				1, 1));
 		((GridData) lblSearch.getLayoutData()).verticalIndent = 3;
 		lblSearch.addMouseListener(new MouseAdapter() {
-
 			@Override
 			public void mouseDown(MouseEvent e) {
-				if (PassportEntryItemEditor.this.userMayEdit)
-				{
-				Label l = (Label) e.getSource();
-				l.setBackground(BTSUIConstants.VIEW_BACKGROUND_LABEL_PRESSED);
+				if (PassportEntryItemEditor.this.userMayEdit) {
+					Label l = (Label) e.getSource();
+					l.setBackground(BTSUIConstants.VIEW_BACKGROUND_LABEL_PRESSED);
 				}
 			}
-
 			@Override
 			public void mouseUp(MouseEvent e) {
-				if (PassportEntryItemEditor.this.userMayEdit)
-				{
-				Label l = (Label) e.getSource();
-				l.setBackground(l.getParent().getBackground());
-				// open search dialog
-				IEclipseContext child = context.createChild("searchselect");
-				context.set(BTSConstants.OBJECT_TYPES_ARRAY, new String[]{BTSConstants.THS_ENTRY});
-				BTSObjectTypeSubtypeViewerFilter viewerFilter = passportConfigurationController.createObjectTypeSubtypeFilterByReferencedPath(corpusObject, itemConfig2);
-				context.set(BTSObjectTypeSubtypeViewerFilter.class, viewerFilter);
-				SearchSelectObjectDialog dialog = ContextInjectionFactory.make(
-						SearchSelectObjectDialog.class, child);
-				if (dialog.open() == dialog.OK) {
-					BTSObject object = dialog.getObject();
-					System.out.println(object.get_id());
-					Command command = SetCommand.create(editingDomain,
-							entry, BtsCorpusModelPackage.eINSTANCE.getBTSPassportEntry_Value(),
-							object.get_id());
-					editingDomain.getCommandStack().execute(command);
-					ths_select_text.setText(object.getName());
-					ths_select_text.setData(object);
-
-				}
+				if (PassportEntryItemEditor.this.userMayEdit) {
+					Label l = (Label) e.getSource();
+					l.setBackground(l.getParent().getBackground());
+					// open search dialog
+					IEclipseContext child = context.createChild("searchselect");
+					context.set(BTSConstants.OBJECT_TYPES_ARRAY, new String[]{BTSConstants.THS_ENTRY});
+					BTSObjectTypeSubtypeViewerFilter viewerFilter = passportConfigurationController.createObjectTypeSubtypeFilterByReferencedPath(corpusObject, itemConfig2);
+					context.set(BTSObjectTypeSubtypeViewerFilter.class, viewerFilter);
+					SearchSelectObjectDialog dialog = ContextInjectionFactory.make(SearchSelectObjectDialog.class, child);
+					if (dialog.open() == Dialog.OK) {
+						BTSObject object = dialog.getObject();
+						Command command = SetCommand.create(editingDomain,
+								entry, BtsCorpusModelPackage.eINSTANCE.getBTSPassportEntry_Value(),
+								object.get_id());
+						editingDomain.getCommandStack().execute(command);
+						ths_select_text.setText(object.getName());
+						ths_select_text.setData(object);
+					}
 				}
 			}
 		});
-		
+
 		Label lblPassportDialog = new Label(this, SWT.NONE);
 		lblPassportDialog.setImage(resourceProvider.getImage(Display.getDefault(),
 				BTSResourceProvider.IMG_PASSPORT));
@@ -714,23 +707,17 @@ public class PassportEntryItemEditor extends PassportEntryEditorComposite {
 		((GridData) lblPassportDialog.getLayoutData()).horizontalIndent = 3;
 
 		lblPassportDialog.addMouseListener(new MouseAdapter() {
-
 			@Override
 			public void mouseDown(MouseEvent e) {
-				
-				Label l = (Label) e.getSource();
-					l.setBackground(BTSUIConstants.VIEW_BACKGROUND_LABEL_PRESSED);
+				 ((Label) e.getSource()).setBackground(BTSUIConstants.VIEW_BACKGROUND_LABEL_PRESSED);
 			}
-
 			@Override
 			public void mouseUp(MouseEvent e) {
-				
-				Label l = (Label) e.getSource();
+				Label l = ((Label) e.getSource());
 				l.setBackground(l.getParent().getBackground());
 				// open search dialog
 				Object o = ths_select_text.getData();
-				if (o != null && o instanceof BTSObject)
-				{
+				if (o != null && o instanceof BTSObject) {
 					BTSObject btso = (BTSObject) o;
 					IEclipseContext child = context.createChild();
 					child.set(BTSObject.class, btso);
@@ -739,14 +726,9 @@ public class PassportEntryItemEditor extends PassportEntryEditorComposite {
 							permissionController.userMayEditObject(
 									permissionController.getAuthenticatedUser(), 
 									btso));
-					
-					PassportEditorDialog dialog = ContextInjectionFactory.make(
-							PassportEditorDialog.class, child);
-					if (dialog.open() == dialog.OK) {
-						
-					}
+					PassportEditorDialog dialog = ContextInjectionFactory.make(PassportEditorDialog.class, child);
+					dialog.open();
 				}
-				
 			}
 		});
 

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/widgets/ObjectSelectionProposalProvider.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/widgets/ObjectSelectionProposalProvider.java
@@ -40,8 +40,7 @@ public class ObjectSelectionProposalProvider implements
 		List<ContentProposal> partialList = new Vector<ContentProposal>();
 		if (list != null && !list.isEmpty()) {
 			for (BTSObject o : list) {
-				if (o.getName() != null && o.getName().startsWith(contents)
-						|| o.get_id().equals(contents)) {
+				if (o.getName() != null) {
 					String desc = o.getName() + "\n" + o.get_id() + "\n" + o.getDBCollectionKey();
 					ContentProposal p = new ContentProposal(o.get_id(), o.getName(), desc);
 					partialList.add(p);

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/widgets/ObjectSelectionProposalProvider.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/widgets/ObjectSelectionProposalProvider.java
@@ -16,7 +16,7 @@ import org.eclipse.jface.fieldassist.IContentProposalProvider;
 public class ObjectSelectionProposalProvider implements
 		IContentProposalProvider {
 
-	private GeneralBTSObjectController gernalObjectController;
+	private GeneralBTSObjectController generalObjectController;
 	private BTSConfig configItem;
 	private List<BTSObject> list;
 	private Comparator<IContentProposal> comparator;
@@ -26,7 +26,7 @@ public class ObjectSelectionProposalProvider implements
 			GeneralBTSObjectController passportEditorController,
 			BTSConfig configItem,
 			BTSObject object) {
-		this.gernalObjectController = passportEditorController;
+		this.generalObjectController = passportEditorController;
 		this.setConfigItem(configItem);
 		this.object = object;
 	}
@@ -73,7 +73,7 @@ public class ObjectSelectionProposalProvider implements
 
 	private List<BTSObject> loadList(final String contents) {
 
-		return gernalObjectController.getObjectProposalsFor(
+		return generalObjectController.getObjectProposalsFor(
 				(BTSConfigItem) configItem, contents, object, null);
 
 	}

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/widgets/ObjectSelectionProposalProvider.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/widgets/ObjectSelectionProposalProvider.java
@@ -41,7 +41,7 @@ public class ObjectSelectionProposalProvider implements
 		if (list != null && !list.isEmpty()) {
 			for (BTSObject o : list) {
 				if (o.getName() != null) {
-					String desc = o.getName() + "\n" + o.get_id() + "\n" + o.getDBCollectionKey();
+					String desc = o.getName() + "\n(" + o.get_id() + " in " + o.getDBCollectionKey() + ")";
 					ContentProposal p = new ContentProposal(o.get_id(), o.getName(), desc);
 					partialList.add(p);
 				}

--- a/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/widgets/RelationEditorComposite.java
+++ b/org.bbaw.bts.ui.main/src/org/bbaw/bts/ui/main/widgets/RelationEditorComposite.java
@@ -198,7 +198,7 @@ public class RelationEditorComposite extends Composite {
 		EMFUpdateValueStrategy modelToTarget = new EMFUpdateValueStrategy();
 		modelToTarget.setConverter(new BTSStringToConfigItemConverter(
 				selectComboViewer));
-		IObservableValue target_type_viewer = ViewersObservables
+		IObservableValue<?> target_type_viewer = ViewersObservables
 				.observeSingleSelection(selectComboViewer);
 		bindingContext.bindValue(
 				target_type_viewer,


### PR DESCRIPTION
### Description
Invoking content assist in passport editor fields (`ctrl + space`) used to cause java heap space overflow errors because of reification of massive object search result lists.

#### Related redmine tickets

  * [#9150](https://redmine.bbaw.de/issues/9150)

### Proposed Fix

Fix queries and logic.

