### PR TITLE
align lemmatizer part lemma searches

### DIFF
--- a/org.bbaw.bts.app.feature/feature.xml
+++ b/org.bbaw.bts.app.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.bbaw.bts.app.feature"
       label="Berlin Text System Core Application"
-      version="3.2.0.qualifier"
+      version="3.2.1.qualifier"
       provider-name="BBAW"
       os="linux,macosx,win32"
       ws="carbon,cocoa,gtk,win32"
@@ -11,6 +11,11 @@
    <description url="http://www.example.com/description">
 Change log
 ==========
+
+Release 3.2.1
+-------------
+
+	- Feature: lemma search dialog emulates lemmatizer search unless searching for ID (3d4a9ff)
 
 Release 3.2.0
 -------------

--- a/org.bbaw.bts.app.product/org.bbaw.bts.app.product
+++ b/org.bbaw.bts.app.product/org.bbaw.bts.app.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="Berlin Text System" uid="org.bbaw.bts.app.product" id="org.bbaw.bts.app.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="3.2.0.qualifier" useFeatures="true" includeLaunchers="true">
+<product name="Berlin Text System" uid="org.bbaw.bts.app.product" id="org.bbaw.bts.app.product" application="org.eclipse.e4.ui.workbench.swt.E4Application" version="3.2.1.qualifier" useFeatures="true" includeLaunchers="true">
 
    <configIni use="default">
    </configIni>
@@ -134,7 +134,7 @@
    </plugins>
 
    <features>
-      <feature id="org.bbaw.bts.app.feature" version="3.2.0.qualifier"/>
+      <feature id="org.bbaw.bts.app.feature" version="3.2.1.qualifier"/>
       <feature id="org.bbaw.bts.corpus.egy.feature" version="3.2.0.qualifier"/>
    </features>
 

--- a/org.bbaw.bts.core.dao/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.core.dao/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Dao
 Bundle-SymbolicName: org.bbaw.bts.core.dao;singleton:=true
-Bundle-Version: 3.1.1.qualifier
+Bundle-Version: 3.2.1.qualifier
 Bundle-Vendor: BBAW
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Service-Component: OSGI-INF/*.xml

--- a/org.bbaw.bts.core.dao/src/org/bbaw/bts/core/dao/util/BTSQueryRequest.java
+++ b/org.bbaw.bts.core.dao/src/org/bbaw/bts/core/dao/util/BTSQueryRequest.java
@@ -108,8 +108,9 @@ public class BTSQueryRequest {
 	}
 	
 	/**
-	 * Sets up a {@link QueryBuilder} according to current configuration. The result can be retrieved via {@link #getQueryBuilder()}.
-	 * 
+	 * Sets up a {@link QueryBuilder} according to current configuration.
+	 * The result can be retrieved via {@link #getQueryBuilder()}.
+	 *
 	 */
 	public void initQueryBuilder() {
 		if (searchString.length() > 0)
@@ -135,7 +136,7 @@ public class BTSQueryRequest {
 				this.setAutocompletePrefix(searchString);
 			}
 			else {
-				this.setQueryBuilder(QueryBuilders.simpleQueryString(escapedString).defaultOperator(Operator.AND));
+				this.setQueryBuilder(QueryBuilders.simpleQueryStringQuery(escapedString).defaultOperator(Operator.AND));
 				this.setAutocompletePrefix(searchString);
 			}
 		}		

--- a/org.bbaw.bts.ui.corpus.egy/META-INF/MANIFEST.MF
+++ b/org.bbaw.bts.ui.corpus.egy/META-INF/MANIFEST.MF
@@ -100,4 +100,4 @@ Import-Package: javax.annotation;version="1.0.0",
  org.eclipse.xtext.resource,
  org.elasticsearch.common.recycler,
  org.mihalis.opal.promptSupport
-Bundle-Version: 3.2.0.qualifier
+Bundle-Version: 3.2.1.qualifier

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyLemmatizerPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyLemmatizerPart.java
@@ -232,7 +232,6 @@ public class EgyLemmatizerPart implements SearchViewer {
 		((GridLayout) parent.getLayout()).marginWidth = 0;
 		if (partService != null) {
 			Collection<MPart> parts = partService.getParts();
-
 		}
 
 		Composite composite = new Composite(parent, SWT.NONE);
@@ -1243,9 +1242,6 @@ public class EgyLemmatizerPart implements SearchViewer {
 	@Override
 	public void search(final BTSQueryRequest query, String queryName,
 			String viewerFilterString) {
-		// create root for lemma tree view
-		final TreeNodeWrapper lemmaRootNode = BtsviewmodelFactory.eINSTANCE
-				.createTreeNodeWrapper();
 
 		// cancel possibly running search
 		if (searchjob != null) {
@@ -1253,20 +1249,25 @@ public class EgyLemmatizerPart implements SearchViewer {
 			searchjob = null;
 		}
 
+		// if this call came from an external handler ('Lupensuche'), don't bother to do anything at all and just
+		// emulate auto search (lemma transliteration content assist) behaviour.
 		if (query.getType() != BTSQueryType.LEMMA) {
 			if (!query.isIdQuery() 
 					&& query.getAutocompletePrefix() != null) {
 				if (!query.isWildcardQuery()) {
-					if (query.getRequestFields().size() == 1 && query.getRequestFields().contains("name")) {
-						searchAuto(query.getSearchString().replaceAll("\\.", ","));
-						return;
-					}
+					searchAuto(query.getSearchString().replaceAll("\\.", ","));
+					return;
 				}
 			}
 		}
 
 		// try to load lemma that has already be assigned to the word currently selected in text editor
 		final String assignedLemmaId = (currentWord != null) ? currentWord.getLKey() : null;
+
+
+		// create root for lemma tree view
+		final TreeNodeWrapper lemmaRootNode = BtsviewmodelFactory.eINSTANCE
+				.createTreeNodeWrapper();
 
 		// fill lemmaViewer
 		searchjob = new Job("load input") {


### PR DESCRIPTION
### Description

Since 4560a95c69acf6094cda1982af7f21c6687969b9, the *name search* or *"exact search"* option in search viewer instance search dialogs is not being activated by default anymore. This lead to a bunch of unexpected behaviour of the lemma search invoked by the standard search viewer dialog handler. To avoid further confusion, the lemmatizer lemma search invoked via the search viewer interface ("Lupensuche") now triggers the lemmatizer part's very own automatic lemma search invoked by its transliteration text field.

#### Related redmine tickets

  * [#10736](https://redmine.bbaw.de/issues/10736)
  * [#10729](https://redmine.bbaw.de/issues/10729)
  * [#10735](https://redmine.bbaw.de/issues/10735)

#### most significant commits for merge

  * 3d4a9ffe44f018a66c2896d6be66ad7ea02baedb