### PR TITLE
Fix rendering of ambivalence cases in STE

### DIFF
--- a/org.bbaw.bts.app.feature/feature.xml
+++ b/org.bbaw.bts.app.feature/feature.xml
@@ -12,6 +12,11 @@
 Change log
 ==========
 
+Release 3.2.3
+-------------
+
+	- Fix: broken ambivalence rendering in Sign Text Editor ()
+
 Release 3.2.2
 -------------
 

--- a/org.bbaw.bts.app.feature/feature.xml
+++ b/org.bbaw.bts.app.feature/feature.xml
@@ -15,7 +15,7 @@ Change log
 Release 3.2.3
 -------------
 
-	- Fix: broken ambivalence rendering in Sign Text Editor ()
+	- Fix: broken ambivalence rendering in Sign Text Editor (d065b27)
 
 Release 3.2.2
 -------------

--- a/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/BTSTextEditorControllerImpl.java
+++ b/org.bbaw.bts.core.corpus.controller.impl/src/org/bbaw/bts/core/corpus/controller/impl/partController/BTSTextEditorControllerImpl.java
@@ -34,6 +34,7 @@ import org.bbaw.bts.btsmodel.BTSInterTextReference;
 import org.bbaw.bts.btsmodel.BTSObject;
 import org.bbaw.bts.btsmodel.BTSRelation;
 import org.bbaw.bts.commons.BTSConstants;
+import org.bbaw.bts.core.commons.corpus.CorpusUtils;
 import org.bbaw.bts.core.corpus.controller.impl.partController.support.TextModelHelper;
 import org.bbaw.bts.core.corpus.controller.partController.BTSTextEditorController;
 import org.bbaw.bts.core.services.corpus.BTSLemmaEntryService;
@@ -382,7 +383,8 @@ public class BTSTextEditorControllerImpl
 					anno.setTempSortKey(counter + GAP);
 				}
 				modelAnnotation = new BTSAnnotationAnnotation(item, reference, anno);
-				if (anno.getType() != null && anno.getType().equalsIgnoreCase("rubrum"))
+				if (anno.getType() != null 
+						&& anno.getType().equalsIgnoreCase(CorpusUtils.ANNOTATION_RUBRUM_TYPE))
 				{
 					modelAnnotation.setText( "org.bbaw.bts.ui.text.modelAnnotation.annotation.rubrum");
 				}

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyLemmaEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyLemmaEditorPart.java
@@ -22,6 +22,7 @@ import org.bbaw.bts.btsmodel.BTSTranslations;
 import org.bbaw.bts.btsmodel.BtsmodelFactory;
 import org.bbaw.bts.commons.BTSPluginIDs;
 import org.bbaw.bts.core.commons.BTSCoreConstants;
+import org.bbaw.bts.core.commons.corpus.CorpusUtils;
 import org.bbaw.bts.core.controller.generalController.EditingDomainController;
 import org.bbaw.bts.core.controller.generalController.PermissionsAndExpressionsEvaluationController;
 import org.bbaw.bts.core.corpus.controller.partController.LemmaEditorController;
@@ -779,7 +780,7 @@ public class EgyLemmaEditorPart extends AbstractTextEditorLogic implements IBTSE
 					&& ((BTSAnnotationAnnotation) a).getRelatingObject()
 							.getType() != null
 					&& ((BTSAnnotationAnnotation) a).getRelatingObject()
-							.getType().equalsIgnoreCase("rubrum")) {
+							.getType().equalsIgnoreCase(CorpusUtils.ANNOTATION_RUBRUM_TYPE)) {
 
 				// Position pos = model.getPosition((Annotation) a);
 				Position pos2 = new Position(pos.getOffset()

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/parts/EgyTextEditorPart.java
@@ -1817,7 +1817,10 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 					&& ((BTSAnnotationAnnotation) a).getRelatingObject()
 							.getType() != null
 					&& ((BTSAnnotationAnnotation) a).getRelatingObject()
-							.getType().equalsIgnoreCase("rubrum")) {
+							.getType().equalsIgnoreCase(
+									CorpusUtils.ANNOTATION_RUBRUM_TYPE
+									)
+							) {
 
 				// Position pos = model.getPosition((Annotation) a);
 				Position pos2 = new Position(pos.getOffset()
@@ -2750,6 +2753,7 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 					strategyId = typeId;
 				}
 				else{
+					// TODO
 					if (typeId.startsWith(BTSConstants.COMMENT))
 					{
 						strategyId = BTSConstants.COMMENT;
@@ -3030,7 +3034,9 @@ public class EgyTextEditorPart extends AbstractTextEditorLogic implements IBTSEd
 		if (object instanceof BTSAnnotation) {
 			if (((BTSAnnotation) object).getType() != null
 					&& ((BTSAnnotation) object).getType().equalsIgnoreCase(
-							"rubrum")) {
+							CorpusUtils.ANNOTATION_RUBRUM_TYPE
+							)
+					) {
 				ta = new BTSAnnotationAnnotation(embeddedEditor.getDocument(),
 						issue, object,
 						(BTSAnnotation) object);

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
@@ -17,6 +17,7 @@ import org.bbaw.bts.btsmodel.BTSObject;
 import org.bbaw.bts.btsmodel.BTSRelation;
 import org.bbaw.bts.commons.BTSConstants;
 import org.bbaw.bts.core.commons.BTSCoreConstants;
+import org.bbaw.bts.core.commons.corpus.CorpusUtils;
 import org.bbaw.bts.core.corpus.controller.partController.BTSTextEditorController;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSAmbivalence;
 import org.bbaw.bts.corpus.btsCorpusModel.BTSAmbivalenceItem;
@@ -117,7 +118,7 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 	@Inject
 	@Preference(value = BTSEGYUIConstants.SIGN_TEXT_SHOW_HIEROGLYPHS, nodePath = "org.bbaw.bts.ui.corpus.egy")
 	private Boolean showHieroglyphs;
-	
+
 	@Inject
 	@Preference(value = BTSEGYUIConstants.SIGN_TEXT_SHOW_FLEXION, nodePath = "org.bbaw.bts.ui.corpus.egy")
 	private Boolean showFlexion;
@@ -673,11 +674,6 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 		// layout.setMinorSpacing(3);
 		canvas.setContents(container);
 		// container.setLayoutManager(layout);
-		
-		System.out.println("max line length: "+max_line_length);
-		for (FontData fd : JFaceResources.getFont("BBAWLibertine").getFontData()) {
-			System.out.println(fd);
-		}
 
 		container.setFocusTraversable(true);
 		this.layout();
@@ -734,7 +730,8 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 	 */
 	private void processStylingAnnotations(ElementFigure itemFigure,
 			BTSObject relatingObject) {
-		if (relatingObject instanceof BTSAnnotation && "rubrum".equals(relatingObject.getType()) 
+		if (relatingObject instanceof BTSAnnotation 
+				&& relatingObject.getType().equals(CorpusUtils.ANNOTATION_RUBRUM_TYPE) 
 				&& itemFigure instanceof WordFigure)
 		{
 			for (Object fig : itemFigure.getChildren()) {
@@ -1135,7 +1132,6 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 		}
 		int len = figure.calculateWidth() + 2;
 				
-		System.out.println("line leng " + (currentLineFigure.getSpaceLength() + len) + " max " + max_line_length); 
 		if (figure.getType().equals(ElementFigure.SENTENCE_START)) {
 			currentLineFigure = makeLineFigure();
 			currentLineFigure.add(figure);

--- a/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
+++ b/org.bbaw.bts.ui.corpus.egy/src/org/bbaw/bts/ui/egy/textSign/SignTextComposite.java
@@ -615,8 +615,9 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 				BTSSenctence sentence = (BTSSenctence) item;
 
 				// insert start Sentence
-				ElementFigure sentenceStart = makeSentenceStartFigure(sentence);
-				appendFigure(sentenceStart);
+				appendFigure(
+						makeSentenceBoundsFigure(sentence, ElementFigure.SENTENCE_START)
+						);
 				for (BTSSentenceItem senItem : sentence.getSentenceItems()) {
 					ElementFigure itemFigure = null;
 					if (senItem instanceof BTSWord) {
@@ -632,7 +633,7 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 					}
 					else if (senItem instanceof BTSAmbivalence) {
 						BTSAmbivalence ambivalence = (BTSAmbivalence) senItem;
-						itemFigure = makeAmbivalenceFigure(ambivalence);
+						makeAmbivalenceFigures(ambivalence);
 
 					}
 					
@@ -656,8 +657,9 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 					}
 
 				}
-				ElementFigure sentenceEnd = makeSentenceEndFigure(sentence);
-				appendFigure(sentenceEnd);
+				appendFigure(
+						makeSentenceBoundsFigure(sentence, ElementFigure.SENTENCE_END)
+						);
 
 			}
 		}
@@ -762,10 +764,11 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 		}
 	}
 
-	private ElementFigure makeAmbivalenceFigure(BTSAmbivalence ambivalence) {
+	private void makeAmbivalenceFigures(BTSAmbivalence ambivalence) {
 
-		ElementFigure ambivalenceStart = makeAmbivalenceStartFigure(ambivalence);
-		appendFigure(ambivalenceStart);
+		appendFigure(
+				makeAmbivalenceBoundsFigure(ambivalence, ElementFigure.AMBIVALENCE_START)
+				);
 
 		for (BTSLemmaCase lemmaCase : ambivalence.getCases()) {
 			ElementFigure caseFigure = makeCaseFigure(lemmaCase);
@@ -776,7 +779,7 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 				if (amItem instanceof BTSWord) {
 					BTSWord word = (BTSWord) amItem;
 					itemFigure = makeWordFigure(word);
-					// appendWord(word);
+					appendFigure(itemFigure);
 				} else if (amItem instanceof BTSMarker) {
 					BTSMarker marker = (BTSMarker) amItem;
 					itemFigure = makeMarkerFigure(marker);
@@ -803,13 +806,13 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 				// process relating Objects
 				}
 			}
-
 		}
-		ElementFigure ambivalenceEnd = makeAmbivalenceEndFigure(ambivalence);
-		appendFigure(ambivalenceEnd);
 
-		return null;
+		appendFigure(
+				makeAmbivalenceBoundsFigure(ambivalence, ElementFigure.AMBIVALENCE_END)
+				);
 	}
+
 
 	private ElementFigure makeCaseFigure(BTSLemmaCase lemmaCase) {
 		MarkerFigure fig = new MarkerFigure("case");
@@ -826,20 +829,16 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 		return fig;
 	}
 
-	private ElementFigure makeAmbivalenceEndFigure(BTSAmbivalence ambivalence) {
-		AmbivalenceEndFigure fig = new AmbivalenceEndFigure("");
 
-		fig.setType(ElementFigure.AMBIVALENCE_END);
-		fig.setModelObject(ambivalence);
-		fig.setSize(15, 90);
-		fig.addMouseListener(elementSelectionListener);
-		return fig;
-	}
-
-	private ElementFigure makeAmbivalenceStartFigure(BTSAmbivalence ambivalence) {
+	/**
+	 * Creates an {@link ElementFigure} instance representing the beginning or the end of an ambivalence
+	 * @param ambivalence the {@link BTSAmbivalence} represented by the to-be-returned figure
+	 * @param type either {@link ElementFigure#AMBIVALENCE_START} or {@link ElementFigure#AMBIVALENCE_END}
+	 * @return
+	 */
+	private ElementFigure makeAmbivalenceBoundsFigure(BTSAmbivalence ambivalence, String type) {
 		AmbivalenceStartFigure fig = new AmbivalenceStartFigure("");
-
-		fig.setType(ElementFigure.AMBIVALENCE_START);
+		fig.setType(type);
 		fig.setModelObject(ambivalence);
 		fig.setSize(15, 90);
 		fig.addMouseListener(elementSelectionListener);
@@ -1168,19 +1167,17 @@ public class SignTextComposite extends Composite implements IBTSEditor {
 		return fig;
 	}
 
-	private ElementFigure makeSentenceStartFigure(BTSSenctence sentence) {
-		MarkerFigure fig = new MarkerFigure(" § ");
-		fig.setModelObject(sentence);
-		fig.setType(ElementFigure.SENTENCE_START);
-		fig.setSize(15, 90);
-		fig.addMouseListener(elementSelectionListener);
-		return fig;
-	}
 
-	private ElementFigure makeSentenceEndFigure(BTSSenctence sentence) {
+	/**
+	 * Creates an {@link ElementFigure} instance representing the beginning or end of a sentence. 
+	 * @param sentence
+	 * @param type either {@link ElementFigure#SENTENCE_START} or {@link ElementFigure#SENTENCE_END}
+	 * @return
+	 */
+	private ElementFigure makeSentenceBoundsFigure(BTSSenctence sentence, String type) {
 		MarkerFigure fig = new MarkerFigure(" § ");
 		fig.setModelObject(sentence);
-		fig.setType(ElementFigure.SENTENCE_END);
+		fig.setType(type);
 		fig.setSize(15, 90);
 		fig.addMouseListener(elementSelectionListener);
 		return fig;


### PR DESCRIPTION
Caused by an error during refactoring in 3a1c6b2, words within ambivalences did not get
rendered anymore. Sad.

#### Related redmine tickets

  * [#11291](https://redmine.bbaw.de/issues/11291)

